### PR TITLE
Added parameter handling to Python script in Rust

### DIFF
--- a/mint-backend-tauri-app/src-tauri/scripts/hello.py
+++ b/mint-backend-tauri-app/src-tauri/scripts/hello.py
@@ -1,1 +1,2 @@
-print("Hello, World from Python!")
+def test(x, y):
+    return f"x + y is equal to {x + y}"


### PR DESCRIPTION
Can now pass in parameters into Python script, which processes the parameters and outputs a result.

1. Run npm run tauri dev
2. When console opens, click on Run Python Script button
3. You should get a result outputted to the terminal as shown below.
![image](https://github.com/user-attachments/assets/785a5a38-2b22-45e4-8465-40f8090f1925)
