### PR TITLE
Redesign toolbar: progress bar

### DIFF
--- a/frontend/components/ui/slider.tsx
+++ b/frontend/components/ui/slider.tsx
@@ -17,10 +17,9 @@ const Slider = React.forwardRef<
     )}
     {...props}
   >
-    <SliderPrimitive.Track className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-primary/20">
-      <SliderPrimitive.Range className="absolute h-full bg-[#2E7B75]" />
+    <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-[#E9E9E9]">
+      <SliderPrimitive.Range className="absolute h-full bg-[#7AB5AD] rounded-full" />
     </SliderPrimitive.Track>
-    <SliderPrimitive.Thumb className="block h-4 w-4 rounded-full border border-primary/50 bg-background shadow transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50" />
   </SliderPrimitive.Root>
 ))
 Slider.displayName = SliderPrimitive.Root.displayName

--- a/frontend/components/ui/timer.tsx
+++ b/frontend/components/ui/timer.tsx
@@ -15,9 +15,9 @@ export const Timer: React.FC<TimerProps> = ({
         <div
             className={`flex items-center space-x-2 font-mono text-xs ${className}`}
         >
-            <span className="text-gray-700 font-medium">{leftTime}</span>
-            <span className="text-gray-400">|</span>
-            <span className="text-gray-700 font-medium">{rightTime}</span>
+            <span className="text-[#64748B] font-lg" style={{fontFamily: 'IBM Plex Sans, sans-serif',}}>{leftTime}</span>
+            <span className="text-[#64748B]">|</span>
+            <span className="text-[#64748B] font-lg" style={{fontFamily: 'IBM Plex Sans, sans-serif',}}>{rightTime}</span>
         </div>
     );
 };


### PR DESCRIPTION
# Task 27: redesign toolbar: progress bar
## What?
Redesigned the toolbar's slider component to visually represent a loading/progress bar for the elapsed time during the data streaming process (max 5 mins).

## How?
- Edited the previous slider component to match new Figma design
- Edited the previous timer component to match new Figma design 

Updated in `settings-bar.tsx`:
- Updated  previous useEffect for timer to now stop automatically after 5 minutes (300 seconds)
- Added new useEffect to stop the stream if timer hits 5 minutes (300 seconds)
- Updated the slider so that it updates progress bar as time passes
- Updated the left/right labels to reflect elapsed and total time

## Testing
- Manually tested edge cases (clicking Start multiple times, Stop, Reset)

Confirmed that:
- Timer starts and progresses when Start Data Stream is clicked
- Timer stops at 5 minutes automatically
- Reset button clears the timer and resets progress bar to 0
- Timer state doesn’t leak or persist between component unmounts/remounts

## Notes
- Also added new handler for the reset button to ensure timer and progress bar both reset cleanly