### PR TITLE
Added PUT and DELETE user endpoints along with some general API documentation

### DIFF
--- a/backend/api-server/src/apidocumentation.md
+++ b/backend/api-server/src/apidocumentation.md
@@ -1,0 +1,127 @@
+
+User Model:
+
+```
+// response from server
+type User = {
+  id: number;          // i32
+  username: string;
+  email: string;
+};
+
+```
+
+The above is how a user is represented in the database. We currently support some key operations with REST. These are broken into several key categories:
+
+### POST - Create Functionality
+
+```
+// POST request body
+type NewUser = {
+  username: string;
+  email: string;
+};
+```
+
+
+To create a user, we send a POST request to the endpoint `BASE_URL/users`. The response will be int he format below:
+
+```
+{
+  "id": 1,
+  "username": "mint",
+  "email": "mint@example.com"
+}
+
+```
+
+### GET - List Functionality
+
+To get the list of users, we can send a GET request to the endpoint of `BASE_URL/users`.
+
+```
+[
+
+    {
+
+        "id": 2,
+
+        "username": "gus",
+
+        "email": "agastya.rai05@gmai.com"
+
+    },
+
+    {
+
+        "id": 3,
+
+        "username": "h",
+
+        "email": "fake_email@gmail.com"
+
+    },
+
+    {
+
+        "id": 4,
+
+        "username": "newgeneric",
+
+        "email": "newgeneric@email.com"
+
+    },
+
+    {
+
+        "id": 5,
+
+        "username": "generic",
+
+        "email": "genericemail@genericdomain.com"
+
+    }
+
+]
+```
+
+
+### PUT - Update Functionality
+
+```
+// PUT (request body; all optional)
+type UpdateUser = {
+  username?: string;
+  email?: string;
+};
+```
+
+To update a user, we send a PUT request to the endpoint with the specified user id in the url, such as `BASE_URL/users/5`. In the JSON, we can pass an updated username or email as parameters.
+
+```
+{
+  "username": "generic_update"
+  "email": "generic_email_updated"
+}
+```
+
+We can choose to update either or both of them individually. If you try to do update nothing (i.e. send an empty JSON), no update will be issued.
+
+
+
+This should respond with the updated user.
+
+```
+{
+  "id": 5,
+  "username": "generic_update",
+  "email": "generic_email_updated"
+}
+
+```
+
+### DELETE - Remove Functionality
+
+To delete a user, we send a DELETE request to the endpoint with the specified user id in the url, such as `BASE_URL/users/5`. No JSON body is needed, just the user ID in the url.
+
+

--- a/backend/shared-logic/src/models.rs
+++ b/backend/shared-logic/src/models.rs
@@ -18,6 +18,13 @@ pub struct NewUser {
     pub email: String,
 }
 
+// Struct for updating a user (partial updates allowed)
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UpdateUser { // the fields are optional, allowing you to update them individually if needed
+    pub username: Option<String>,
+    pub email: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
 pub struct TimeSeriesData {
     pub id: i32,


### PR DESCRIPTION
This rounds out the current functionality, to give the `/users` endpoint full CRUD.

### Changes
- `backend/api-server/src/main.rs`
  - Added `PUT /users/id handler` for user updates.
  - Added `DELETE /users/id handler` for user deletion.
  - Updated the router to map the new routes
  - Imported the new `UpdateUser` model
- `backend/api-server/src/models.rs`
  - Added an `UpdateUser` struct with optional username and email fields
- `backend/api-server/src/db.rs`
  - Implemented the function `update_user` to allow for partial updates
  - Implemented the function `delete_user` to allow for removing users by id
 
The endpoints were tested locally using Postman. Additionally, some general API documentation can be found in the file `apidocumentation.md` in `backend/api-server/src`.