### PR TITLE
Update websocket for changed signal structure 

### DIFF
--- a/backend/shared-logic/src/lsl.rs
+++ b/backend/shared-logic/src/lsl.rs
@@ -28,7 +28,7 @@ pub struct ProcessingConfig {
 impl Default for ProcessingConfig {
     fn default() -> Self {
         Self {
-            apply_bandpass: true,
+            apply_bandpass: false,
             use_iir: false,
             l_freq: Some(1.0),
             h_freq: Some(50.0),

--- a/frontend/components/nodes/signal-graph-node/signal-graph-full.tsx
+++ b/frontend/components/nodes/signal-graph-node/signal-graph-full.tsx
@@ -14,14 +14,13 @@ import { Button } from '@/components/ui/button';
 
 
 interface SignalGraphViewProps {
-   data: {
-       time: string;
-       signal1: number;
-       signal2: number;
-       signal3: number;
-       signal4: number;
-       signal5: number;
-   }[];
+    data: {
+        time: string;
+        signal1: number;
+        signal2: number;
+        signal3: number;
+        signal4: number;
+    }[];
 }
 
 
@@ -29,15 +28,12 @@ export default function SignalGraphView({ data }: SignalGraphViewProps) {
    const { dataStreaming, setDataStreaming } = useGlobalContext();
    const [selectedSignal, setSelectedSignal] = useState<string | null>(null);
 
-
-   const signals = [
-       { key: 'signal1', colour: '#0000ff', name: 'Signal 1' },
-       { key: 'signal2', colour: '#00ff00', name: 'Signal 2' },
-       { key: 'signal3', colour: '#FF00D0', name: 'Signal 3' },
-       { key: 'signal4', colour: '#FFFF00', name: 'Signal 4' },
-       { key: 'signal5', colour: '#ff0000', name: 'Signal 5' },
-   ];
-
+    const signals = [
+        {key: 'signal1', colour: '#0000ff', name: 'Signal 1'},
+        {key: 'signal2', colour: '#00ff00', name: 'Signal 2'},
+        {key: 'signal3', colour: '#FF00D0', name: 'Signal 3'},
+        {key: 'signal4', colour: '#FFFF00', name: 'Signal 4'},
+    ];
 
    const handleStartStop = () => {
        setDataStreaming(!dataStreaming);

--- a/frontend/components/nodes/signal-graph-node/signal-graph-node.tsx
+++ b/frontend/components/nodes/signal-graph-node/signal-graph-node.tsx
@@ -18,15 +18,7 @@ import SignalGraphView from './signal-graph-full';
 export default function SignalGraphNode({ id }: { id?: string }) {
     const { renderData } = useWebsocket(20, 10);
 
-    const processedData = renderData.map((item) => ({
-        time: item.time,
-        signal1: item.signals[0],
-        signal2: item.signals[1],
-        signal3: item.signals[2],
-        signal4: item.signals[3],
-        signal5: item.signals[4],
-    }));
-
+    const processedData = renderData;
     const reactFlowInstance = useReactFlow();
     const [isConnected, setIsConnected] = React.useState(false);
     const { dataStreaming } = useGlobalContext()

--- a/frontend/components/ui-data-table/data-table.tsx
+++ b/frontend/components/ui-data-table/data-table.tsx
@@ -14,7 +14,6 @@ interface SignalData {
     signal2: number;
     signal3: number;
     signal4: number;
-    signal5: number;
 }
 
 interface DataTableProps {
@@ -33,7 +32,6 @@ const DataTable: React.FC<DataTableProps> = ({ rowCount = 8, data = [] }) => {
                     signal2: 0,
                     signal3: 0,
                     signal4: 0,
-                    signal5: 0,
                 }
             );
         });
@@ -57,9 +55,6 @@ const DataTable: React.FC<DataTableProps> = ({ rowCount = 8, data = [] }) => {
                         </TableHead>
                         <TableHead className="text-center font-medium text-[#0D585F]">
                             Signal 4
-                        </TableHead>
-                        <TableHead className="text-center font-medium text-[#0D585F]">
-                            Signal 5
                         </TableHead>
                     </TableRow>
                 </TableHeader>
@@ -85,9 +80,6 @@ const DataTable: React.FC<DataTableProps> = ({ rowCount = 8, data = [] }) => {
                             </TableCell>
                             <TableCell className="text-center text-[#0D585F]">
                                 {row.signal4}
-                            </TableCell>
-                            <TableCell className="text-center text-[#0D585F]">
-                                {row.signal5}
                             </TableCell>
                         </TableRow>
                     ))}

--- a/frontend/hooks/useWebsocket.tsx
+++ b/frontend/hooks/useWebsocket.tsx
@@ -24,6 +24,17 @@ export default function useWebsocket(
           console.log('Sent processing config:', config)
         }
     }      
+    const normalizeBatch = (batch: any) => {
+        const { time, signals } = batch;
+        
+        return [{
+            time,
+            signal1: signals[0],
+            signal2: signals[1],
+            signal3: signals[2],
+            signal4: signals[3],
+        }];
+    };
 
     useEffect(() => {
         console.log('data streaming:', dataStreaming);
@@ -76,7 +87,8 @@ export default function useWebsocket(
                 } else {
                     try {
                         const parsedData = JSON.parse(message);
-                        bufferRef.current.push(parsedData);
+                        const normalizedPoints = normalizeBatch(parsedData);
+                        bufferRef.current.push(...normalizedPoints);
                     } catch (e) {
                         console.error("Failed to parse non-confirmation message as JSON:", e, message);
                     }

--- a/frontend/hooks/useWebsocket.tsx
+++ b/frontend/hooks/useWebsocket.tsx
@@ -25,15 +25,13 @@ export default function useWebsocket(
         }
     }      
     const normalizeBatch = (batch: any) => {
-        const { time, signals } = batch;
-        
-        return [{
+        return batch.timestamps.map((time: number, i: number) => ({
             time,
-            signal1: signals[0],
-            signal2: signals[1],
-            signal3: signals[2],
-            signal4: signals[3],
-        }];
+            signal1: batch.signals[0][i],
+            signal2: batch.signals[1][i],
+            signal3: batch.signals[2][i],
+            signal4: batch.signals[3][i],
+        }));
     };
 
     useEffect(() => {

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -1,3 +1,4 @@
+const { time } = require('console');
 const WebSocket = require('ws');
 
 const wss = new WebSocket.Server({ port: 8080 });
@@ -6,11 +7,16 @@ wss.on('connection', (ws) => {
     console.log('New client connected');
 
     const interval = setInterval(() => {
+
+        const timestamps = Array.from({ length: 20 }, (_, i) => 
+            Date.now() + i * 3
+        );
+        const signals = Array.from({ length: 4 }, () =>
+            Array.from({ length: 65 }, () => Math.floor(Math.random() * 100))
+        );
         const data = {
-            time: Date.now(), // Using milliseconds since epoch for time
-            signals: Array.from({ length: 5 }, () =>
-                Math.floor(Math.random() * 100)
-            ), // Random values for 5 brain regions
+            timestamps,
+            signals,
         };
 
         ws.send(JSON.stringify(data));


### PR DESCRIPTION
What?

- Updated websocket to normalize new data format

How?

- Mapped the batches in websocket instead of signal-graph-node, for the new 2D array format
- Ensured the entries were in the format of time, signal1, signal2, signal3, signal4
- Changed server.js to send sample data with the new batched format

Test pictures:
<img width="1607" height="809" alt="image" src="https://github.com/user-attachments/assets/64875834-c695-410b-9e06-99203996dcf0" />

Snapshot of backend log:
<img width="1584" height="823" alt="image" src="https://github.com/user-attachments/assets/8aa996f9-dc3e-44af-8dc9-6761eef8e744" />
