### PR TITLE
Fix websocket connection

### DIFF
--- a/frontend/components/nodes/filter-node/combo-box.tsx
+++ b/frontend/components/nodes/filter-node/combo-box.tsx
@@ -32,16 +32,15 @@ interface ComboBoxProps {
 export default function ComboBox({
     value = 'lowpass',
     onValueChange,
+    lowCutoff,
+    highCutoff,
+    setLowCutoff,
+    setHighCutoff,
     isConnected = false,
     isDataStreamOn = false,
 }: ComboBoxProps) {
     const [isExpanded, setIsExpanded] = React.useState(false);
     const titleRef = React.useRef<HTMLSpanElement>(null);
-    const [sliderValue, setSliderValue] = React.useState([75]);
-    const [cutoff, setCutoff] = React.useState([75]);
-
-    const [lowCutoff, setLowCutoff] = React.useState([25]);
-    const [highCutoff, setHighCutoff] = React.useState([75]);
 
     const toggleExpanded = () => {
         setIsExpanded(!isExpanded);
@@ -140,21 +139,17 @@ export default function ComboBox({
                     paddingRight: '60px',
                 }}
             >
-                {value != 'bandpass' && (
+                {value !== 'bandpass' && (
                     <div>
                         <Slider
-                            value={sliderValue}
+                            value={value === 'lowpass' ? [highCutoff] : [lowCutoff]}
                             onValueChange={(val) => {
-                                setSliderValue(val);
-                        
                                 if (value === 'lowpass') {
-                                  setHighCutoff(val);   
+                                    setHighCutoff(val[0]);
+                                } else {
+                                    setLowCutoff(val[0]);
                                 }
-                        
-                                if (value === 'highpass') {
-                                  setLowCutoff(val);    
-                                }
-                              }}
+                            }}
                             max={100}
                             min={0}
                             step={1}
@@ -167,29 +162,19 @@ export default function ComboBox({
                     </div>
                 )}
 
-                {/* Single slider for lowpass and highpass */}
-                {value == 'bandpass' && (
+                {value === 'bandpass' && (
                     <div>
                         {/* Low cutoff */}
-                        <div>
-
-                            <Slider
-                                value={lowCutoff}
-                                onValueChange={(val) => {
-                                    // prevent low from going above high
-                                    const next =
-                                        val[0] >= highCutoff[0]
-                                            ? highCutoff[0] - 1
-                                            : val[0];
-                                    setLowCutoff([next]);
-                                }}
-                                min={0}
-                                max={100}
-                                step={1}
-                                className="w-full mb-1"
-                            />
-                        </div>
-
+                        <Slider
+                            value={[lowCutoff]}
+                            onValueChange={(val) => {
+                                setLowCutoff(Math.min(val[0], highCutoff - 1));
+                            }}
+                            min={0}
+                            max={100}
+                            step={1}
+                            className="w-full mb-1"
+                        />
                         <div className="flex justify-between items-center mb-5">
                             <span className="text-xs text-gray-500">0</span>
                             <span className="text-xs text-gray-500">Low Cutoff</span>
@@ -197,24 +182,16 @@ export default function ComboBox({
                         </div>
 
                         {/* High cutoff */}
-                        <div>
-                            <Slider
-                                value={highCutoff}
-                                onValueChange={(val) => {
-                                    // prevent high from going below low
-                                    const next =
-                                        val[0] <= lowCutoff[0]
-                                            ? lowCutoff[0] + 1
-                                            : val[0];
-                                    setHighCutoff([next]);
-                                }}
-                                min={0}
-                                max={100}
-                                step={1}
-                                className="w-full mb-1"
-                            />
-                        </div>
-
+                        <Slider
+                            value={[highCutoff]}
+                            onValueChange={(val) => {
+                                setHighCutoff(Math.max(val[0], lowCutoff + 1));
+                            }}
+                            min={0}
+                            max={100}
+                            step={1}
+                            className="w-full mb-1"
+                        />
                         <div className="flex justify-between items-center mb-1">
                             <span className="text-xs text-gray-500">0</span>
                             <span className="text-xs text-gray-500">High Cutoff</span>

--- a/frontend/components/nodes/filter-node/filter-node.tsx
+++ b/frontend/components/nodes/filter-node/filter-node.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { Handle, Position, useReactFlow } from '@xyflow/react';
 import { useGlobalContext } from '@/context/GlobalContext';
 import ComboBox from './combo-box';
-import useWebsocket from '@/hooks/useWebsocket';
 import { ProcessingConfig } from '@/lib/processing';
 
 interface FilterNodeProps {
@@ -22,8 +21,6 @@ export default function FilterNode({ id }: FilterNodeProps) {
     
     // Get data stream status from global context
     const { dataStreaming } = useGlobalContext();
-
-    const { sendProcessingConfig } = useWebsocket(0, 0)
 
     const buildConfig = (): ProcessingConfig => {
         if (!isConnected) {
@@ -138,9 +135,13 @@ export default function FilterNode({ id }: FilterNodeProps) {
     }, [checkConnectionStatus]);
 
     React.useEffect(() => {
-        if (!dataStreaming) return
-        sendProcessingConfig(buildConfig())
-    }, [selectedFilter, lowCutoff, highCutoff, isConnected, dataStreaming])  
+        if (!dataStreaming) return;
+        window.dispatchEvent(
+            new CustomEvent<ProcessingConfig>('processing-config-update', {
+                detail: buildConfig(),
+            })
+        );
+    }, [selectedFilter, lowCutoff, highCutoff, isConnected, dataStreaming]);
 
     return (
         <div className="relative">
@@ -196,23 +197,6 @@ export default function FilterNode({ id }: FilterNodeProps) {
                 isDataStreamOn={dataStreaming}
             />
 
-            {isConnected && (
-            <>
-                <input
-                type="range"
-                min={1}
-                max={100}
-                value={cutoff}
-                onChange={(e) => setCutoff(Number(e.target.value))}
-                />
-
-                <p className="text-xs text-muted-foreground">
-                {selectedFilter === 'lowpass'
-                    ? 'Frequencies below cutoff will pass through'
-                    : 'Frequencies above cutoff will pass through'}
-                </p>
-            </>
-            )}
         </div>
     );
 }

--- a/frontend/hooks/useWebsocket.tsx
+++ b/frontend/hooks/useWebsocket.tsx
@@ -2,6 +2,16 @@ import { useEffect, useState, useRef } from 'react';
 import { useGlobalContext } from '@/context/GlobalContext';
 import { ProcessingConfig } from '@/lib/processing';
 
+const DEFAULT_PROCESSING_CONFIG: ProcessingConfig = {
+    apply_bandpass: false,
+    use_iir: false,
+    l_freq: null,
+    h_freq: null,
+    downsample_factor: null,
+    sfreq: 256,
+    n_channels: 4,
+};
+
 export default function useWebsocket(
     chartSize: number,
     batchesPerSecond: number
@@ -23,7 +33,16 @@ export default function useWebsocket(
           wsRef.current.send(JSON.stringify(config))
           console.log('Sent processing config:', config)
         }
-    }      
+    }
+
+    useEffect(() => {
+        const handleConfigUpdate = (event: Event) => {
+            sendProcessingConfig((event as CustomEvent<ProcessingConfig>).detail);
+        };
+        window.addEventListener('processing-config-update', handleConfigUpdate);
+        return () => window.removeEventListener('processing-config-update', handleConfigUpdate);
+    }, []);
+
     const normalizeBatch = (batch: any) => {
         return batch.timestamps.map((time: number, i: number) => ({
             time,
@@ -65,10 +84,7 @@ export default function useWebsocket(
 
             ws.onopen = () => {
                 console.log('WebSocket connection opened.');
-
-                if (processingConfigRef.current) {
-                    ws.send(JSON.stringify(processingConfigRef.current))
-                }
+                ws.send(JSON.stringify(processingConfigRef.current ?? DEFAULT_PROCESSING_CONFIG));
             };
 
             ws.onmessage = (event) => {


### PR DESCRIPTION
# Fix websocket connection

## What?

- the filter node was opening its own separate WebSocket connection solely to send the processing config, while the signal graph node opened a different connection to receive data
- the backend (handle_connection) always reads the first message as the processing config before starting the broadcast
- so the signal graph's connection would hang indefinitely waiting for a config that never arrived on it

---

## How?

- removed useWebsocket(0, 0) from filter-node.tsx. Instead, the filter node dispatches a processing-config-update custom window event with the current config whenever streaming starts or filter settings change
- added an event listener in useWebsocket that picks up processing-config-update events and forwards the config to the backend on the active connection
- changed onopen in useWebsocket to always send a default passthrough config if no filter config has been set yet, ensuring the backend always receives a first message and starts broadcasting
- fixed combo-box.tsx ignoring the lowCutoff/highCutoff/setLowCutoff/setHighCutoff props; the sliders were updating internal local state that was never passed back to the parent's buildConfig(), so filter cutoff values had no effect

---

## Testing

- confirmed Docker build succeeds for websocket-server after removing the Windows-only import
- verified in browser console that "WebSocket connection opened." logs on stream start
- confirmed no "Error parsing signal configuration JSON" errors appear in websocket-server logs
- tested Source to Chart View pipeline: data flows to chart on stream start
- tested Source to Filter to Chart View pipeline: data flows and filter type/cutoff changes dispatch config update events
<img width="1246" height="666" alt="Screenshot 2026-03-10 at 8 41 50 PM" src="https://github.com/user-attachments/assets/152dc5a6-34b1-4e8a-9284-1d515ed1310a" />

