### PR TITLE
labeling node backend refactor for frontend fields

### DIFF
--- a/backend/migrations/20260310120000_update_time_labels.sql
+++ b/backend/migrations/20260310120000_update_time_labels.sql
@@ -1,0 +1,4 @@
+ALTER TABLE time_labels RENAME COLUMN timestamp TO start_timestamp;
+ALTER TABLE time_labels ADD COLUMN end_timestamp TIMESTAMPTZ;
+ALTER TABLE time_labels ADD COLUMN color TEXT NOT NULL DEFAULT '';
+ALTER TABLE time_labels ALTER COLUMN color DROP DEFAULT;

--- a/backend/shared-logic/src/db.rs
+++ b/backend/shared-logic/src/db.rs
@@ -372,13 +372,15 @@ pub async fn insert_time_labels(client: &DbClient, session_id: i32, labels: Vec<
     }
 
     let mut query_builder = sqlx::QueryBuilder::new(
-        "INSERT INTO time_labels (session_id, timestamp, label) "
+        "INSERT INTO time_labels (session_id, start_timestamp, end_timestamp, label, color) "
     );
 
     query_builder.push_values(labels.iter(), |mut b, label| {
         b.push_bind(session_id)
-            .push_bind(label.timestamp)
-            .push_bind(&label.label);
+            .push_bind(label.start_timestamp)
+            .push_bind(label.end_timestamp)
+            .push_bind(&label.label)
+            .push_bind(&label.color);
     });
 
     query_builder.build().execute(&**client).await?;
@@ -416,7 +418,7 @@ pub async fn get_time_labels_by_range(client: &DbClient, session_id: i32, start:
 
     let labels = sqlx::query_as!(
         TimeLabel,
-        "SELECT id, session_id, timestamp, label FROM time_labels WHERE session_id = $1 AND timestamp >= $2 AND timestamp <= $3 ORDER BY timestamp",
+        "SELECT id, session_id, start_timestamp, end_timestamp, label, color FROM time_labels WHERE session_id = $1 AND start_timestamp >= $2 AND start_timestamp <= $3 ORDER BY start_timestamp",
         session_id,
         start,
         end,

--- a/backend/shared-logic/src/models.rs
+++ b/backend/shared-logic/src/models.rs
@@ -54,16 +54,20 @@ pub struct FrontendState {
 pub struct TimeLabel {
     pub id: i32,
     pub session_id: i32,
-    pub timestamp: DateTime<Utc>,
+    pub start_timestamp: DateTime<Utc>,
+    pub end_timestamp: Option<DateTime<Utc>>,
     pub label: String,
+    pub color: String,
 }
 
 // Struct for a time label coming INTO the API from the frontend
 // No id (auto-generated) or session_id (comes from URL path)
 #[derive(Debug, Serialize, Deserialize)]
 pub struct NewTimeLabel {
-    pub timestamp: DateTime<Utc>,
+    pub start_timestamp: DateTime<Utc>,
+    pub end_timestamp: Option<DateTime<Utc>>,
     pub label: String,
+    pub color: String,
 }
 
 // Struct for a row of EEG data coming OUT of the DB


### PR DESCRIPTION
## What?

Updated the time_labels backend to support additional fields required by the frontend:
  - Renamed timestamp to start_timestamp
  - Added end_timestamp (nullable for in progress labels)
  - Added color (required) to store the label's display color
---

---

## How?


Migration (update_time_labels.sql):
  - Renames timestamp to start_timestamp
  - Adds nullable end_timestamp TIMESTAMPTZ
  - Adds color TEXT NOT NULL

  Models (models.rs):
  - Updated TimeLabel and NewTimeLabel structs to include start_timestamp, end_timestamp (as Option<DateTime<Utc>>), and color

  DB functions (db.rs):
  - insert_time_labels(); updated column list and bindings to include new fields
  - get_time_labels_by_range(); updated SELECT and WHERE to use start_timestamp

---

## Testing

Postman testing:
<img width="562" height="372" alt="get session id" src="https://github.com/user-attachments/assets/aa077c1b-d02b-4b01-8660-314fc1731ad1" />
1. POST /api/sessions - created session to get a valid session_id
<p>
</p>
<img width="548" height="469" alt="post timestamps" src="https://github.com/user-attachments/assets/16bde743-5681-48f1-bb2a-e7f77dc56779" />
<p>
</p>
2. POST /api/sessions/:id/time-label - 201 response, posted first label with start_timestamp, end_timestamp, label, and color
<p>
</p>
<img width="550" height="466" alt="post timestamps null end" src="https://github.com/user-attachments/assets/4d6ec497-d078-42d3-a177-c021016a55c9" />
<p>
</p>
3. POST /api/sessions/:id/time-label - 201 response, posted second label with end_timestamp: null to verify nullable case
<p>
</p>
<img width="553" height="706" alt="get label by timestamps" src="https://github.com/user-attachments/assets/06d4f723-787c-485d-9b78-89685f5820da" />
<p>
</p>
4. GET /api/sessions/:id/time-label?start=...&end=... - wide time range returns both labels, including the one with null
<p>
</p>
<img width="557" height="595" alt="get label by timestamps no first" src="https://github.com/user-attachments/assets/04aaa545-1ee3-40f0-bd5d-5b9becb4c7e7" />
<p>
</p>
5. GET /api/sessions/:id/time-label?start=...&end=... - narrow range starting after the first label ends returns only the second
