### PR TITLE
Resampling node

### DIFF
--- a/frontend/components/nodes/resampling-node/resampling-combo-box.tsx
+++ b/frontend/components/nodes/resampling-node/resampling-combo-box.tsx
@@ -1,0 +1,133 @@
+import * as React from 'react';
+import { ChevronUp } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+const PRESET_OPTIONS = [
+    { value: 'input', label: 'Input size' },
+    { value: '200', label: '200 Hz' },
+    { value: '256', label: '256 Hz' },
+];
+
+export type ResampleRate = '200' | '256' | 'input' | 'custom';
+
+interface ResamplingComboBoxProps {
+    rate: ResampleRate;
+    customRate: number;
+    onRateChange: (rate: ResampleRate) => void;
+    onCustomRateChange: (hz: number) => void;
+    isConnected?: boolean;
+    isDataStreamOn?: boolean;
+}
+
+export default function ResamplingComboBox({
+    rate,
+    customRate,
+    onRateChange,
+    onCustomRateChange,
+    isConnected = false,
+    isDataStreamOn = false,
+}: ResamplingComboBoxProps) {
+    const [isExpanded, setIsExpanded] = React.useState(false);
+
+    const selectedLabel =
+        PRESET_OPTIONS.find((o) => o.value === rate)?.label ??
+        (rate === 'custom' ? `${customRate} Hz` : 'Resampling');
+
+    return (
+        <div
+            className={cn('bg-white rounded-[30px] border-2 overflow-hidden', 'border-[#D3D3D3]')}
+            style={{ width: 'fit-content', minWidth: '396px' }}
+        >
+            {/* Header */}
+            <button
+                onClick={() => setIsExpanded(!isExpanded)}
+                className="w-full h-[55px] px-4 flex items-center justify-between transition-colors"
+            >
+                <div className="flex items-center">
+                    <div
+                        className={cn(
+                            'absolute left-6 w-6 h-6 rounded-full border-[3px] flex items-center justify-center bg-white',
+                            isConnected ? 'border-black' : 'border-gray-300'
+                        )}
+                    />
+                    <div
+                        className={cn(
+                            'absolute left-16 w-3 h-3 rounded-full',
+                            isConnected && isDataStreamOn ? 'bg-[#509693]' : 'bg-[#D3D3D3]'
+                        )}
+                    />
+                    <span className="absolute left-24 font-geist text-[25px] font-[550] leading-tight text-black tracking-wider">
+                        Resampling
+                    </span>
+                </div>
+                <div className="flex items-center">
+                    <div className="absolute right-[58px]">
+                        <ChevronUp
+                            className={`h-5 w-5 text-gray-600 transform transition-all duration-300 ease-in-out ${isExpanded ? 'rotate-0' : 'rotate-180'}`}
+                        />
+                    </div>
+                    <div
+                        className={cn(
+                            'absolute right-6 w-6 h-6 rounded-full border-[3px] flex items-center justify-center bg-white',
+                            isConnected ? 'border-black' : 'border-gray-300'
+                        )}
+                    />
+                </div>
+            </button>
+
+            {/* Expanded options */}
+            <div
+                className="overflow-hidden"
+                style={{
+                    maxHeight: isExpanded ? '280px' : '0px',
+                    opacity: isExpanded ? 1 : 0,
+                    transition: 'max-height 0.3s ease-in-out, opacity 0.3s ease-in-out',
+                }}
+            >
+                <div className="flex flex-col pb-4" style={{ paddingLeft: '60px', paddingRight: '60px' }}>
+                    <div className="flex flex-col space-y-0.5">
+                        {PRESET_OPTIONS.map((option) => (
+                            <button
+                                key={option.value}
+                                onClick={() => onRateChange(option.value as ResampleRate)}
+                                className={cn(
+                                    'text-left px-3 py-1 text-sm rounded-lg transition-colors',
+                                    rate === option.value
+                                        ? 'bg-gray-100 text-gray-900'
+                                        : 'text-gray-600 hover:bg-gray-50'
+                                )}
+                            >
+                                {option.label}
+                            </button>
+                        ))}
+                        <button
+                            onClick={() => onRateChange('custom')}
+                            className={cn(
+                                'text-left px-3 py-1 text-sm rounded-lg transition-colors',
+                                rate === 'custom'
+                                    ? 'bg-gray-100 text-gray-900'
+                                    : 'text-gray-600 hover:bg-gray-50'
+                            )}
+                        >
+                            Custom
+                        </button>
+                    </div>
+
+                    {/* Custom Hz input */}
+                    {rate === 'custom' && (
+                        <div className="mt-2 px-3 flex items-center gap-2">
+                            <input
+                                type="number"
+                                min={1}
+                                value={customRate}
+                                onChange={(e) => onCustomRateChange(Number(e.target.value))}
+                                className="w-24 border border-gray-300 rounded-lg px-2 py-1 text-sm text-gray-800 focus:outline-none focus:ring-1 focus:ring-[#509693]"
+                            />
+                            <span className="text-sm text-gray-500">Hz</span>
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/frontend/components/nodes/resampling-node/resampling-node.tsx
+++ b/frontend/components/nodes/resampling-node/resampling-node.tsx
@@ -1,0 +1,102 @@
+'use client';
+import { useGlobalContext } from '@/context/GlobalContext';
+import { Handle, Position, useReactFlow } from '@xyflow/react';
+import React from 'react';
+import ResamplingComboBox, { ResampleRate } from './resampling-combo-box';
+
+interface ResamplingNodeProps {
+    id: string;
+    data?: any;
+}
+
+export default function ResamplingNode({ id, data }: ResamplingNodeProps) {
+    const [rate, setRate] = React.useState<ResampleRate>(data?.rate ?? '256');
+    const [customRate, setCustomRate] = React.useState<number>(data?.customRate ?? 256);
+    const [isConnected, setIsConnected] = React.useState(false);
+
+    const reactFlowInstance = useReactFlow();
+    const { dataStreaming } = useGlobalContext();
+
+    // Persist state to node data
+    React.useEffect(() => {
+        reactFlowInstance.updateNodeData(id, { rate, customRate });
+    }, [id, rate, customRate, reactFlowInstance]);
+
+    // Dispatch config update for future websocket integration
+    React.useEffect(() => {
+        const hz = rate === 'input' ? null : rate === 'custom' ? customRate : Number(rate);
+        window.dispatchEvent(new CustomEvent('resampling-config-update', { detail: { resample_hz: hz } }));
+    }, [rate, customRate]);
+
+    const checkConnectionStatus = React.useCallback(() => {
+        try {
+            const edges = reactFlowInstance.getEdges();
+            const nodes = reactFlowInstance.getNodes();
+            const reachesSource = (nodeId: string, visited: Set<string> = new Set()): boolean => {
+                if (visited.has(nodeId)) return false;
+                visited.add(nodeId);
+                for (const edge of edges.filter((e) => e.target === nodeId)) {
+                    const src = nodes.find((n) => n.id === edge.source);
+                    if (!src) continue;
+                    if (src.type === 'source-node') return true;
+                    if (reachesSource(src.id, visited)) return true;
+                }
+                return false;
+            };
+            setIsConnected(id ? reachesSource(id) : false);
+        } catch {
+            setIsConnected(false);
+        }
+    }, [id, reactFlowInstance]);
+
+    React.useEffect(() => {
+        checkConnectionStatus();
+        window.addEventListener('reactflow-edges-changed', checkConnectionStatus);
+        const interval = setInterval(checkConnectionStatus, 1000);
+        return () => {
+            window.removeEventListener('reactflow-edges-changed', checkConnectionStatus);
+            clearInterval(interval);
+        };
+    }, [checkConnectionStatus]);
+
+    return (
+        <div className="relative">
+            <Handle
+                type="target"
+                position={Position.Left}
+                id="resampling-input"
+                style={{
+                    left: '24px', top: '45px',
+                    transform: 'translateY(-50%)',
+                    width: '28px', height: '28px',
+                    backgroundColor: 'transparent',
+                    border: '2px solid transparent',
+                    borderRadius: '50%',
+                    zIndex: 20, cursor: 'crosshair', pointerEvents: 'all',
+                }}
+            />
+            <Handle
+                type="source"
+                position={Position.Right}
+                id="resampling-output"
+                style={{
+                    right: '24px', top: '45px',
+                    transform: 'translateY(-50%)',
+                    width: '28px', height: '28px',
+                    backgroundColor: 'transparent',
+                    border: '2px solid transparent',
+                    borderRadius: '50%',
+                    zIndex: 20, cursor: 'crosshair', pointerEvents: 'all',
+                }}
+            />
+            <ResamplingComboBox
+                rate={rate}
+                customRate={customRate}
+                onRateChange={setRate}
+                onCustomRateChange={setCustomRate}
+                isConnected={isConnected}
+                isDataStreamOn={dataStreaming}
+            />
+        </div>
+    );
+}

--- a/frontend/components/ui-react-flow/react-flow-view.tsx
+++ b/frontend/components/ui-react-flow/react-flow-view.tsx
@@ -27,6 +27,7 @@ import SourceNode from '@/components/nodes/source-node';
 import ArtifactNode from '@/components/nodes/artifact-node/artifact-node';
 import FilterNode from '@/components/nodes/filter-node/filter-node';
 import MachineLearningNode from '@/components/nodes/machine-learning-node/machine-learning-node';
+import ResamplingNode from '@/components/nodes/resampling-node/resampling-node';
 import SignalGraphNode from '@/components/nodes/signal-graph-node/signal-graph-node';
 import WindowNode from '@/components/nodes/window-node/window-node';
 
@@ -44,6 +45,7 @@ const nodeTypes = {
     'source-node': SourceNode,
     'artifact-node': ArtifactNode,
     'filter-node': FilterNode,
+    'resampling-node': ResamplingNode,
     'machine-learning-node': MachineLearningNode,
     'signal-graph-node': SignalGraphNode,
     'window-node': WindowNode,
@@ -245,8 +247,13 @@ const ReactFlowInterface = () => {
                 return sourceNode.type === 'source-node';
             }
 
-            // Allow Source → Filter or Artifact → Filter
+            // Allow Source / Artifact / Resampling → Filter
             if (targetNode.type === 'filter-node') {
+                return sourceNode.type === 'source-node' || sourceNode.type === 'artifact-node' || sourceNode.type === 'resampling-node';
+            }
+
+            // Allow Source / Artifact → Resampling
+            if (targetNode.type === 'resampling-node') {
                 return sourceNode.type === 'source-node' || sourceNode.type === 'artifact-node';
             }
 

--- a/frontend/components/ui-sidebar/sidebar.tsx
+++ b/frontend/components/ui-sidebar/sidebar.tsx
@@ -46,6 +46,12 @@ export default function Sidebar() {
             category: 'Nodes',
         },
         {
+            id: 'resampling-node',
+            label: 'Resampling Node',
+            description: 'Resample EEG data to a target frequency',
+            category: 'Nodes',
+        },
+        {
             id: 'window-node',
             label: 'Window Node',
             description: 'Configure windowing parameters for data streams',


### PR DESCRIPTION
## What?

Built the initial Resampling Node for the pipeline canvas, allowing users to set a target sample rate for EEG data.

---

## How?

- Created resampling-combo-box.tsx and resampling-node.tsx under a new resampling-node/ directory, following the same structure and design as existing nodes.
- Preset options: Input size, 200 Hz, 256 Hz, and Custom (with a number input).
- Node dispatches a resampling-config-update event for future WebSocket integration.
- Registered in react-flow-view.tsx with connection validation.
- Added to sidebar.tsx for drag-and-drop access.

---

## Testing

- Dragged node onto canvas and verified it renders correctly.
- Confirmed valid/invalid connections are enforced as expected.
- Verified resampling-config-update fires with the correct resample_hz value when rate is changed.
- Confirmed state restores correctly after workspace save/reload.

<img width="486" height="268" alt="Screenshot 2026-04-09 at 2 53 37 PM" src="https://github.com/user-attachments/assets/24f689a3-d7a3-4b57-aea9-368f173b0304" />
<img width="477" height="300" alt="Screenshot 2026-04-09 at 2 54 02 PM" src="https://github.com/user-attachments/assets/43eb9470-0d3b-4678-9d2f-7ebf3f5ffb97" />