### PR TITLE
rust to python gateway

### DIFF
--- a/backend/shared-logic/src/db.rs
+++ b/backend/shared-logic/src/db.rs
@@ -534,6 +534,7 @@ pub async fn import_eeg_data_from_csv(client: &DbClient, session_id: i32, csv_by
     let eeg_rows = EEGDataPacket {
         timestamps,
         signals: vec![channel1_data, channel2_data, channel3_data, channel4_data],
+        ml_result: None,
     };
 
     insert_batch_eeg(client, session_id, &eeg_rows).await?;

--- a/backend/shared-logic/src/lsl.rs
+++ b/backend/shared-logic/src/lsl.rs
@@ -6,12 +6,14 @@ use lsl::{resolve_bypred, Pullable, StreamInlet};
 use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast::Sender;
 use tokio_util::sync::CancellationToken;
-use crate::signal_processing::signal_processor::SignalProcessor;
+// use crate::signal_processing::signal_processor::SignalProcessor;
+use crate::signal_processing::pipeline_gateway::{PipelineGateway, PipelineOutput};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct EEGDataPacket {
     pub timestamps: Vec<DateTime<Utc>>,
     pub signals: Vec<Vec<f64>>,
+    pub ml_result: Option<PipelineOutput>,
 }
 
 #[derive(Clone, Deserialize)]
@@ -57,17 +59,21 @@ impl Default for WindowingConfig {
 // Async entry point for EEG data collection.
 pub async fn receive_eeg(tx:Sender<Arc<EEGDataPacket>>, cancel_token: CancellationToken, processing_config: ProcessingConfig, windowing_rx: tokio::sync::watch::Receiver<WindowingConfig>,) {
     info!("Starting EEG data receiver");
-    let python_script_path = std::env::var("SIGNAL_PROCESSING_SCRIPT")
-    .unwrap_or_else(|_| "../shared-logic/src/signal_processing/signalProcessing.py".to_string());
+    // let python_script_path = std::env::var("SIGNAL_PROCESSING_SCRIPT")
+    //     .unwrap_or_else(|_| "../shared-logic/src/signal_processing/signalProcessing.py".to_string());
+
+    let manager_script_path = std::env::var("PIPELINE_MANAGER_SCRIPT")
+        .unwrap_or_else(|_| "../shared-logic/src/signal_processing/moss/mock_manager.py".to_string());
 
     let result = tokio::task::spawn_blocking(move || {
-        // Setup signal processor
-        let sig_processor = match SignalProcessor::new(&python_script_path) {
-            Ok(p) => p,
+        // Setup pipeline gateway (replaces SignalProcessor)
+        // let sig_processor = match SignalProcessor::new(&python_script_path) { ... };
+        let gateway = match PipelineGateway::new(&manager_script_path) {
+            Ok(g) => g,
             Err(e) => {
                 info!("current path: {:?}", std::env::current_dir());
-                info!("Looking for Python script at: {}", python_script_path);
-                error!("Failed to initialize signal processor: {}", e);
+                info!("Looking for manager script at: {}", manager_script_path);
+                error!("Failed to initialize pipeline gateway: {}", e);
                 return (0, 0);
             }
         };
@@ -80,9 +86,9 @@ pub async fn receive_eeg(tx:Sender<Arc<EEGDataPacket>>, cancel_token: Cancellati
                 return (0, 0);
             }
         };
-        
+
         // Run collection loop
-        run_eeg_collection(inlet, tx, cancel_token, processing_config, sig_processor, windowing_rx)
+        run_eeg_collection(inlet, tx, cancel_token, processing_config, gateway, windowing_rx)
     });
 
     // Handle results
@@ -116,10 +122,10 @@ fn setup_eeg_stream() -> Result<StreamInlet, String> {
 // Main EEG data collection loop.
 // Returns (successful_count, dropped_count) statistics.
 fn run_eeg_collection(inlet: StreamInlet,
-    tx: Sender<Arc<EEGDataPacket>>, 
+    tx: Sender<Arc<EEGDataPacket>>,
     cancel_token: CancellationToken,
     config: ProcessingConfig,
-    processor: SignalProcessor,
+    gateway: PipelineGateway,
     mut windowing_rx: tokio::sync::watch::Receiver<WindowingConfig>,
 ) -> (u32, u32) {
     let mut count = 0;
@@ -134,6 +140,7 @@ fn run_eeg_collection(inlet: StreamInlet,
     let mut packet = EEGDataPacket {
         timestamps: Vec::with_capacity(windowing.chunk_size + 1),
         signals: vec![Vec::with_capacity(windowing.chunk_size + 1); 4],
+        ml_result: None,
     };
 
     // Calculate the offset between LSL clock and Unix epoch
@@ -154,7 +161,7 @@ fn run_eeg_collection(inlet: StreamInlet,
             // Send any remaining samples before exiting
              if !packet.timestamps.is_empty() {
                  let num_samples = packet.timestamps.len();
-                match process_and_send(&mut packet, &processor, &config, &tx) {
+                match process_and_send(&mut packet, &gateway, &config, &tx) {
                     Ok(_) => count += 1,
                     Err(e) => {
                         error!("Process/send error: {}", e);
@@ -196,7 +203,7 @@ fn run_eeg_collection(inlet: StreamInlet,
                         
                         // Packet is full, send it
                         info!("Packet is full, sending window: {} samples (overlap: {})", packet.signals[0].len(), keep);
-                         match process_and_send(&mut packet, &processor, &config, &tx) {
+                         match process_and_send(&mut packet, &gateway, &config, &tx) {
                             Ok(_) => count += 1,
                             Err(e) => {
                                 error!("Process/send error: {}", e);
@@ -266,10 +273,10 @@ fn accumulate_sample(
     Ok(packet.signals[0].len() >= chunk_size)
 }
 
-// calls the signalProcessing.py to process the packet and sends it
+// calls the Python pipeline manager to process the packet and sends it
 fn process_and_send(
     packet: &mut EEGDataPacket,
-    processor: &SignalProcessor,
+    gateway: &PipelineGateway,
     config: &ProcessingConfig,
     tx: &Sender<Arc<EEGDataPacket>>,
 ) -> Result<(), String> {
@@ -277,18 +284,32 @@ fn process_and_send(
         return Err("Empty packet".to_string());
     }
 
-    // Apply bandpass filter
-    info!("starting signal processing");
-    info!("Before: {:?}", packet.signals);
-    if config.apply_bandpass {
-        packet.signals = if config.use_iir {
-            processor.apply_iir_bandpass(&packet.signals, config.sfreq, config.l_freq, config.h_freq)?
-        } else {
-            processor.apply_fir_bandpass(&packet.signals, config.sfreq, config.l_freq, config.h_freq)?
-        };
-    }
-    info!("done signal processing");
-    info!("after: {:?}", packet.signals);
+    // Call the Python pipeline manager (replaces direct SignalProcessor PyO3 calls)
+    info!("starting pipeline processing");
+    packet.ml_result = match gateway.call_pipeline(config, &packet.signals) {
+        Ok(Some(output)) => {
+            info!("ML result: task={}, label={}, confidence={:.2}", output.task, output.overall_label, output.confidence);
+            Some(output)
+        }
+        Ok(None) => {
+            info!("Pipeline ran but returned no classifier output");
+            None
+        }
+        Err(e) => {
+            error!("Pipeline gateway error: {}", e);
+            None
+        }
+    };
+    info!("done pipeline processing");
+
+    // // Old PyO3 calls via SignalProcessor — replaced by gateway above
+    // if config.apply_bandpass {
+    //     packet.signals = if config.use_iir {
+    //         processor.apply_iir_bandpass(&packet.signals, config.sfreq, config.l_freq, config.h_freq)?
+    //     } else {
+    //         processor.apply_fir_bandpass(&packet.signals, config.sfreq, config.l_freq, config.h_freq)?
+    //     };
+    // }
 
     //  // Log last 5 samples before filtering
     // for (ch_idx, channel) in packet.signals.iter().enumerate() {

--- a/backend/shared-logic/src/signal_processing/mod.rs
+++ b/backend/shared-logic/src/signal_processing/mod.rs
@@ -1,1 +1,2 @@
 pub mod signal_processor;
+pub mod pipeline_gateway;

--- a/backend/shared-logic/src/signal_processing/moss/manager.py
+++ b/backend/shared-logic/src/signal_processing/moss/manager.py
@@ -248,6 +248,11 @@ async def run_pipeline(pipeline, data):
     }
 
 
+def run_pipeline_sync(pipeline, data):
+    """Synchronous entry point for PyO3. Wraps run_pipeline so Rust can call it without async handling."""
+    return asyncio.run(run_pipeline(pipeline, data))
+
+
 if __name__ == "__main__":
     # quick async smoke test with generated data (preprocessing only)
     test_pipeline = {

--- a/backend/shared-logic/src/signal_processing/moss/mock_manager.py
+++ b/backend/shared-logic/src/signal_processing/moss/mock_manager.py
@@ -1,0 +1,13 @@
+def run_pipeline_sync(pipeline, data):
+    return {
+        "processed_eeg": None,
+        "classifier_output": {
+            "status": "ok",
+            "task": "focus",
+            "overall_label": "focused",
+            "confidence": 0.85,
+            "segments": [{"label": "focused", "confidence": 0.85}],
+            "class_probabilities": {"focused": 0.85, "unfocused": 0.15},
+            "n_segments": 1,
+        },
+    }

--- a/backend/shared-logic/src/signal_processing/pipeline_gateway.rs
+++ b/backend/shared-logic/src/signal_processing/pipeline_gateway.rs
@@ -1,0 +1,172 @@
+use log::error;
+use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyList, PyModule};
+use numpy::PyArray2;
+use serde::{Deserialize, Serialize};
+
+use crate::lsl::ProcessingConfig;
+
+pub struct PipelineGateway {
+    manager_module: Py<PyModule>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PipelineOutput {
+    pub overall_label: String,
+    pub confidence: f64,
+    pub task: String,
+}
+
+impl PipelineGateway {
+    pub fn new(manager_script_path: &str) -> Result<Self, String> {
+        Python::with_gil(|py| {
+            let code = std::fs::read_to_string(manager_script_path)
+                .map_err(|e| format!("Failed to read manager script: {}", e))?;
+
+            let module = PyModule::from_code(py, &code, "manager.py", "manager")
+                .map_err(|e| format!("Failed to load manager module: {}", e))?;
+
+            Ok(Self {
+                manager_module: module.into(),
+            })
+        })
+    }
+
+    pub fn call_pipeline(
+        &self,
+        config: &ProcessingConfig,
+        signals: &[Vec<f64>],
+    ) -> Result<Option<PipelineOutput>, String> {
+        Python::with_gil(|py| {
+            let module = self.manager_module.as_ref(py);
+
+            // Translate ProcessingConfig into the dict format manager.py expects
+            let pipeline_dict = build_python_pipeline_dict(py, config)?;
+
+            // Transpose signals from (4, n_samples) → (n_samples, 4) as manager.py expects
+            let transposed = transpose_signals(signals);
+            let np_array = PyArray2::from_vec2(py, &transposed)
+                .map_err(|e| format!("Failed to create numpy array: {}", e))?;
+
+            let result = module
+                .call_method1("run_pipeline_sync", (pipeline_dict, np_array))
+                .map_err(|e| format!("Python pipeline error: {}", e))?;
+
+            let classifier_output = result
+                .get_item("classifier_output")
+                .map_err(|e| format!("Failed to get classifier_output: {}", e))?;
+
+            if classifier_output.is_none() {
+                return Ok(None);
+            }
+
+            let overall_label: String = classifier_output
+                .get_item("overall_label")
+                .map_err(|e| format!("Missing overall_label: {}", e))?
+                .extract()
+                .map_err(|e| format!("Failed to extract overall_label: {}", e))?;
+
+            let confidence: f64 = classifier_output
+                .get_item("confidence")
+                .map_err(|e| format!("Missing confidence: {}", e))?
+                .extract()
+                .map_err(|e| format!("Failed to extract confidence: {}", e))?;
+
+            let task: String = classifier_output
+                .get_item("task")
+                .map_err(|e| format!("Missing task: {}", e))?
+                .extract()
+                .map_err(|e| format!("Failed to extract task: {}", e))?;
+
+            Ok(Some(PipelineOutput {
+                overall_label,
+                confidence,
+                task,
+            }))
+        })
+    }
+}
+
+// Translates ProcessingConfig into the dict format manager.py expects.
+// The field names differ between Rust and Python:
+//   Rust ProcessingConfig.sfreq   → Python config "src_fs"
+//   Rust ProcessingConfig.h_freq  → Python config "Filter"
+//   Rust ProcessingConfig.l_freq  → Python config "low_cut_hz"
+//   Rust ProcessingConfig.use_iir → Python config "method" ("IIR" or "FIR")
+fn build_python_pipeline_dict<'py>(
+    py: Python<'py>,
+    config: &ProcessingConfig,
+) -> Result<&'py PyDict, String> {
+    let nodes_list = PyList::empty(py);
+
+    if config.apply_bandpass {
+        let bandpass_config = PyDict::new(py);
+        bandpass_config.set_item("method", if config.use_iir { "IIR" } else { "FIR" })
+            .map_err(|e| format!("Failed to set method: {}", e))?;
+        bandpass_config.set_item("Filter", config.h_freq.unwrap_or(50.0))
+            .map_err(|e| format!("Failed to set Filter: {}", e))?;
+        bandpass_config.set_item("low_cut_hz", config.l_freq.unwrap_or(1.0))
+            .map_err(|e| format!("Failed to set low_cut_hz: {}", e))?;
+        bandpass_config.set_item("src_fs", config.sfreq)
+            .map_err(|e| format!("Failed to set src_fs: {}", e))?;
+
+        let node_dict = PyDict::new(py);
+        node_dict.set_item("type", "bandpass filter")
+            .map_err(|e| format!("Failed to set node type: {}", e))?;
+        node_dict.set_item("config", bandpass_config)
+            .map_err(|e| format!("Failed to set node config: {}", e))?;
+        nodes_list.append(node_dict)
+            .map_err(|e| format!("Failed to append bandpass node: {}", e))?;
+    }
+
+    let pipeline_dict = PyDict::new(py);
+    pipeline_dict.set_item("nodes", nodes_list)
+        .map_err(|e| format!("Failed to set nodes: {}", e))?;
+
+    Ok(pipeline_dict)
+}
+
+// Transposes EEG signals from (n_channels, n_samples) to (n_samples, n_channels).
+// Rust stores signals as Vec<Vec<f64>> shaped (4, n_samples) — channels first.
+// manager.py expects (n_samples, 4) — samples first.
+pub fn transpose_signals(signals: &[Vec<f64>]) -> Vec<Vec<f64>> {
+    if signals.is_empty() || signals[0].is_empty() {
+        return Vec::new();
+    }
+    let n_channels = signals.len();
+    let n_samples = signals[0].len();
+    let mut transposed = vec![vec![0.0_f64; n_channels]; n_samples];
+    for (ch, channel) in signals.iter().enumerate() {
+        for (s, &val) in channel.iter().enumerate() {
+            transposed[s][ch] = val;
+        }
+    }
+    transposed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::transpose_signals;
+
+    #[test]
+    fn test_transpose_four_channels() {
+        // 4 channels, 2 samples: [[1,2],[3,4],[5,6],[7,8]]
+        // expected (n_samples, 4): [[1,3,5,7],[2,4,6,8]]
+        let signals = vec![
+            vec![1.0_f64, 2.0],
+            vec![3.0_f64, 4.0],
+            vec![5.0_f64, 6.0],
+            vec![7.0_f64, 8.0],
+        ];
+        let result = transpose_signals(&signals);
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0], vec![1.0, 3.0, 5.0, 7.0]);
+        assert_eq!(result[1], vec![2.0, 4.0, 6.0, 8.0]);
+    }
+
+    #[test]
+    fn test_transpose_empty() {
+        let result = transpose_signals(&[]);
+        assert!(result.is_empty());
+    }
+}


### PR DESCRIPTION
## What?

Implemented the rust to python gateway that calls the `manager.py` pipeline manager via PyO3. The gateway replaces the old direct `SignalProcessor` PyO3 calls with a single call to `run_pipeline_sync`, which runs the full pipeline (bandpass filter + ML) in sequence.

I also added a `mock_manager.py` for testing the bridge without loading the heavy NeuroLM model.

The gateway converts the Rust `ProcessingConfig` struct into the Python dict format `manager.py` expects:
```json
{
  "nodes": [
    {"type": "bandpass filter", "config": {"method": "FIR", "Filter": 50.0, "src_fs": 256, "low_cut_hz": 1.0}}
  ]
}
```

ML results are attached to `EEGDataPacket.ml_result` and sent back to the frontend via WebSocket.

---

## How?

- Added `mock_manager.py`: same interface as `manager.py`, returns hardcoded output for testing without loading the NeuroLM model
- Added `run_pipeline_sync` wrapper to `manager.py` so Rust can call the async pipeline synchronously via PyO3
- Created `pipeline_gateway.rs` with `PipelineGateway` struct that:
  - Loads the manager script via PyO3 (path from `PIPELINE_MANAGER_SCRIPT` env var, defaults to `mock_manager.py`)
  - Translates `ProcessingConfig` field names to what `manager.py` expects (`sfreq` → `src_fs`, `h_freq` → `Filter`, `l_freq` → `low_cut_hz`, `use_iir` → `method`)
  - Transposes EEG signals from `(4, n_samples)` to `(n_samples, 4)` before passing to Python
  - Calls `run_pipeline_sync(pipeline_dict, eeg_array)` and extracts `classifier_output`
- Commented out old `SignalProcessor` PyO3 calls in `lsl.rs`, replaced with `PipelineGateway`
- Added `ml_result: Option<PipelineOutput>` to `EEGDataPacket` so classifier output is included in WebSocket messages back to the frontend

---

## Testing

- `cargo build -p shared-logic` compiles clean with no errors
- Unit tests for `transpose_signals` pass (`cargo test transpose`)
- Ran `python mock_manager.py` locally to confirm the mock interface works