### PR TITLE
On Tiyas Behalf - Session fix 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,4 @@
 node_modules/
-# Ignore specific queries in backend
-backend/.sqlx/*.json
-backend/.sqlx/query-*
 target/
 backend/shared-logic/src/signal_processing/moss/checkpoints/ 
 backend/shared-logic/src/signal_processing/moss/moss_models/*.npz 

--- a/backend/.sqlx/query-11e96cfd8c2736f13ce55975ea910dd68640f6f14e38a4b3342d514804e3de27.json
+++ b/backend/.sqlx/query-11e96cfd8c2736f13ce55975ea910dd68640f6f14e38a4b3342d514804e3de27.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM sessions WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "11e96cfd8c2736f13ce55975ea910dd68640f6f14e38a4b3342d514804e3de27"
+}

--- a/backend/.sqlx/query-20a3ec47946f35ed0b3ab72931b145f357e4235d21780a58127d1fe04095613c.json
+++ b/backend/.sqlx/query-20a3ec47946f35ed0b3ab72931b145f357e4235d21780a58127d1fe04095613c.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT session_id, data, updated_at FROM frontend_state WHERE session_id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "session_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "data",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 2,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "20a3ec47946f35ed0b3ab72931b145f357e4235d21780a58127d1fe04095613c"
+}

--- a/backend/.sqlx/query-4c7575ee45f7cef7cf00ce1e56608329a7ebafdd7d4b84ed4c3cf057ae574e28.json
+++ b/backend/.sqlx/query-4c7575ee45f7cef7cf00ce1e56608329a7ebafdd7d4b84ed4c3cf057ae574e28.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO sessions (name) VALUES ($1) RETURNING id, name",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "4c7575ee45f7cef7cf00ce1e56608329a7ebafdd7d4b84ed4c3cf057ae574e28"
+}

--- a/backend/.sqlx/query-5201684aeecf596a502b51f0d9768aa85c937cf931773fe06a7c7d49457fed36.json
+++ b/backend/.sqlx/query-5201684aeecf596a502b51f0d9768aa85c937cf931773fe06a7c7d49457fed36.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id, name FROM sessions",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "5201684aeecf596a502b51f0d9768aa85c937cf931773fe06a7c7d49457fed36"
+}

--- a/backend/.sqlx/query-7a25ec7a7cf6011706337e95ef95cfb259ba56c8721ab6105ebfc7aa1fd66c6f.json
+++ b/backend/.sqlx/query-7a25ec7a7cf6011706337e95ef95cfb259ba56c8721ab6105ebfc7aa1fd66c6f.json
@@ -1,0 +1,48 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT time, channel1, channel2, channel3, channel4 FROM eeg_data WHERE session_id = $1 AND time >= $2 AND time <= $3 ORDER BY time",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "time",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 1,
+        "name": "channel1",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "channel2",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 3,
+        "name": "channel3",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 4,
+        "name": "channel4",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "Timestamptz",
+        "Timestamptz"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "7a25ec7a7cf6011706337e95ef95cfb259ba56c8721ab6105ebfc7aa1fd66c6f"
+}

--- a/backend/.sqlx/query-9bab1709d596b1bb8229cce0852bd512b346e1010c5db360b76421210b84ef01.json
+++ b/backend/.sqlx/query-9bab1709d596b1bb8229cce0852bd512b346e1010c5db360b76421210b84ef01.json
@@ -1,0 +1,35 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO frontend_state (session_id, data) VALUES ($1, $2)\n        ON CONFLICT (session_id) DO UPDATE SET data = EXCLUDED.data, updated_at = NOW()\n        RETURNING session_id, data, updated_at",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "session_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "data",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 2,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "Jsonb"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "9bab1709d596b1bb8229cce0852bd512b346e1010c5db360b76421210b84ef01"
+}

--- a/backend/.sqlx/query-a2a9301d0df1164092ed47c4dd22e30de27ac96bacc8202e3599eead9a9a2a00.json
+++ b/backend/.sqlx/query-a2a9301d0df1164092ed47c4dd22e30de27ac96bacc8202e3599eead9a9a2a00.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT MIN(time) as earliest_time FROM eeg_data WHERE session_id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "earliest_time",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "a2a9301d0df1164092ed47c4dd22e30de27ac96bacc8202e3599eead9a9a2a00"
+}

--- a/backend/.sqlx/query-c8d86267771fd7e629e8a2fd739efbae54cbcad667d3c121950c3f7e369c13e7.json
+++ b/backend/.sqlx/query-c8d86267771fd7e629e8a2fd739efbae54cbcad667d3c121950c3f7e369c13e7.json
@@ -1,0 +1,54 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id, session_id, start_timestamp, end_timestamp, label, color FROM time_labels WHERE session_id = $1 AND start_timestamp >= $2 AND start_timestamp <= $3 ORDER BY start_timestamp",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "session_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "start_timestamp",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 3,
+        "name": "end_timestamp",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 4,
+        "name": "label",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "color",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "Timestamptz",
+        "Timestamptz"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "c8d86267771fd7e629e8a2fd739efbae54cbcad667d3c121950c3f7e369c13e7"
+}

--- a/backend/.sqlx/query-ec20520047483f7f1e2e7896a45018cc8993f1607f665c8653aac9ca54f04160.json
+++ b/backend/.sqlx/query-ec20520047483f7f1e2e7896a45018cc8993f1607f665c8653aac9ca54f04160.json
@@ -1,0 +1,48 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT time, channel1, channel2, channel3, channel4 FROM eeg_data\n        WHERE session_id = $1 AND time >= $2 AND time <= $3\n        ORDER BY time ASC",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "time",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 1,
+        "name": "channel1",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "channel2",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 3,
+        "name": "channel3",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 4,
+        "name": "channel4",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "Timestamptz",
+        "Timestamptz"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "ec20520047483f7f1e2e7896a45018cc8993f1607f665c8653aac9ca54f04160"
+}

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1139,8 +1139,6 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 [[package]]
 name = "lsl"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1853f0e53f4c3f03d0275a146de3cbf57462b0bb8f32fa822f024b17faf9dfa"
 dependencies = [
  "lsl-sys",
 ]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -5,3 +5,6 @@ members = [
     "websocket-server",
 ]
 resolver = "2"
+
+[patch.crates-io]
+lsl = { path = "lsl-patched" }

--- a/backend/api-server/Dockerfile
+++ b/backend/api-server/Dockerfile
@@ -27,6 +27,9 @@ COPY .sqlx ./.sqlx
 # Copy shared-logic source (it's a library used by both servers)
 COPY shared-logic/src ./shared-logic/src
 
+# Copy patched lsl crate to override the broken crates.io version
+COPY lsl-patched ./lsl-patched
+
 # Copy migrations directory for the final image
 COPY migrations ./migrations
 

--- a/backend/api-server/src/main.rs
+++ b/backend/api-server/src/main.rs
@@ -1,6 +1,7 @@
 use axum::{
     extract::State,
     extract::Path,
+    extract::Query,
     http::StatusCode,
     routing::{get, post},
     Json,
@@ -24,8 +25,8 @@ use axum::response::IntoResponse;
 use rand_core::OsRng;
 
 // shared logic library
-use shared_logic::db::{DbClient, initialize_connection, export_eeg_data_as_csv, get_earliest_eeg_timestamp};
-use shared_logic::models::{NewUser, Session, FrontendState};
+use shared_logic::db::{DbClient, initialize_connection, export_eeg_data_as_csv, get_eeg_data_by_range, get_earliest_eeg_timestamp, get_time_labels_by_range};
+use shared_logic::models::{User, NewUser, UpdateUser, Session, FrontendState, TimeLabel, NewTimeLabel, EegDataRow, EegDataQuery};
 
 // Argon2 imports
 use argon2::{
@@ -346,6 +347,69 @@ async fn export_eeg_data(
         
 }
 
+// Handler for POST /api/sessions/{session_id}/time-label
+// Receives a batch of time labels from the frontend after a session ends and stores them in the DB.
+async fn store_time_labels(
+    State(app_state): State<AppState>,       // DB connection pool
+    Path(session_id): Path<i32>,             // session ID from the URL path
+    Json(labels): Json<Vec<NewTimeLabel>>,   // array of {timestamp, label} objects from the request body
+) -> Result<StatusCode, (StatusCode, String)> {
+    info!("Received request to store {} time labels for session {}", labels.len(), session_id);
+
+    match shared_logic::db::insert_time_labels(&app_state.db_client, session_id, labels).await {
+        Ok(_) => {
+            info!("Time labels stored successfully for session {}", session_id);
+            Ok(StatusCode::CREATED) // 201 — write-only, nothing to return
+        }
+        Err(e) => {
+            error!("Failed to store time labels: {}", e);
+            Err((StatusCode::INTERNAL_SERVER_ERROR, format!("Failed to store time labels: {}", e)))
+        }
+    }
+}
+
+// Handler for GET /api/sessions/{session_id}/time-label
+// Returns time labels within a given time range (passed as ?start=...&end=... query params).
+async fn get_time_labels(
+    State(app_state): State<AppState>,
+    Path(session_id): Path<i32>,
+    Query(params): Query<EegDataQuery>,
+) -> Result<Json<Vec<TimeLabel>>, (StatusCode, String)> {
+    info!("Received request to get time labels for session {} from {} to {}", session_id, params.start, params.end);
+
+    match get_time_labels_by_range(&app_state.db_client, session_id, params.start, params.end).await {
+        Ok(labels) => {
+            info!("Retrieved {} time labels", labels.len());
+            Ok(Json(labels))
+        }
+        Err(e) => {
+            error!("Failed to get time labels: {}", e);
+            Err((StatusCode::INTERNAL_SERVER_ERROR, format!("Failed to get time labels: {}", e)))
+        }
+    }
+}
+
+// Handler for GET /api/sessions/{session_id}/eeg-data
+// Returns EEG data rows within a given time range (passed as ?start=...&end=... query params).
+async fn get_eeg_data(
+    State(app_state): State<AppState>,      // DB connection pool
+    Path(session_id): Path<i32>,            // session ID from the URL path
+    Query(params): Query<EegDataQuery>,     // ?start=...&end=... parsed into EegDataQuery struct
+) -> Result<Json<Vec<EegDataRow>>, (StatusCode, String)> {
+    info!("Received request to get EEG data for session {} from {} to {}", session_id, params.start, params.end);
+
+    match get_eeg_data_by_range(&app_state.db_client, session_id, params.start, params.end).await {
+        Ok(rows) => {
+            info!("Retrieved {} EEG data rows", rows.len());
+            Ok(Json(rows))
+        }
+        Err(e) => {
+            error!("Failed to get EEG data: {}", e);
+            Err((StatusCode::INTERNAL_SERVER_ERROR, format!("Failed to get EEG data: {}", e)))
+        }
+    }
+}
+
 // Handler for POST /api/sessions/{session_id}/eeg_data/import
 async fn import_eeg_data(
     State(app_state): State<AppState>,
@@ -464,6 +528,10 @@ async fn main() {
         
         .route("/api/sessions/:session_id/frontend-state", post(set_frontend_state))
         .route("/api/sessions/:session_id/frontend-state", get(get_frontend_state))
+
+        .route("/api/sessions/:session_id/time-label", post(store_time_labels))
+        .route("/api/sessions/:session_id/time-label", get(get_time_labels))
+        .route("/api/sessions/:session_id/eeg-data", get(get_eeg_data))
 
         .route("/api/sessions/:session_id/eeg_data/export", post(export_eeg_data))
         .route("/api/sessions/:session_id/eeg_data/import", post(import_eeg_data))

--- a/backend/migrations/20260219120000_add_time_labels.sql
+++ b/backend/migrations/20260219120000_add_time_labels.sql
@@ -1,0 +1,9 @@
+-- add time_labels table to store event labels attached to EEG timestamps during sessions
+
+CREATE TABLE IF NOT EXISTS time_labels (
+  id         SERIAL PRIMARY KEY,
+  session_id INTEGER NOT NULL
+    REFERENCES sessions(id) ON DELETE CASCADE,
+  timestamp  TIMESTAMPTZ NOT NULL,    -- timestamp of the EEG data with timezone info
+  label      TEXT NOT NULL           -- label for the EEG data
+);

--- a/backend/migrations/20260301000000_unique_eeg_session_time.sql
+++ b/backend/migrations/20260301000000_unique_eeg_session_time.sql
@@ -1,4 +1,0 @@
--- we enforce uniqueness on imports through imposing a unique constraint on the 
--- combination of session_id and time, preventing duplicate entries for the same session and timestamp
-ALTER TABLE eeg_data
-ADD CONSTRAINT uq_eeg_session_time UNIQUE (session_id, time);

--- a/backend/migrations/20260310120000_update_time_labels.sql
+++ b/backend/migrations/20260310120000_update_time_labels.sql
@@ -1,0 +1,4 @@
+ALTER TABLE time_labels RENAME COLUMN timestamp TO start_timestamp;
+ALTER TABLE time_labels ADD COLUMN end_timestamp TIMESTAMPTZ;
+ALTER TABLE time_labels ADD COLUMN color TEXT NOT NULL DEFAULT '';
+ALTER TABLE time_labels ALTER COLUMN color DROP DEFAULT;

--- a/backend/migrations/20263101120000_sessions_on_eeg_data.sql
+++ b/backend/migrations/20263101120000_sessions_on_eeg_data.sql
@@ -4,5 +4,10 @@ ALTER TABLE eeg_data
 ADD COLUMN session_id INTEGER NOT NULL,
 ADD CONSTRAINT fk_session FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE;
 
+-- we enforce uniqueness on imports through imposing a unique constraint on the 
+-- combination of session_id and time, preventing duplicate entries for the same session and timestamp
+ALTER TABLE eeg_data
+ADD CONSTRAINT uq_eeg_session_time UNIQUE (session_id, time);
+
 -- we can create an index on session_id and time, since the bulk of our queries will be filtering based on these
 CREATE INDEX eeg_data_session_time_idx ON eeg_data (session_id, time DESC); -- using DESC since i'm expecting recent data to be more relevant

--- a/backend/shared-logic/src/db.rs
+++ b/backend/shared-logic/src/db.rs
@@ -7,7 +7,7 @@ use tokio::time::{self, Duration};
 use log::{info, error, warn};
 use chrono::{Date, DateTime, Utc};
 use dotenvy::dotenv;
-use super::models::{User, NewUser, TimeSeriesData, UpdateUser, Session, FrontendState};
+use super::models::{User, NewUser, TimeSeriesData, UpdateUser, Session, FrontendState, TimeLabel, NewTimeLabel, EegDataRow};
 use crate::{lsl::EEGDataPacket};
 use once_cell::sync::OnceCell;
 use std::sync::Arc;
@@ -418,6 +418,75 @@ pub async fn get_frontend_state(client: &DbClient, session_id: i32) -> Result<Op
     info!("Retrieved frontend state successfully: {:?}", state);
 
     return Ok(state.map(|s| s.data));
+}
+
+/// Insert a batch of time labels for a given session.
+///
+/// Takes a session_id and a list of labels (each with a timestamp and label string),
+/// and inserts them all into the time_labels table in a single query.
+pub async fn insert_time_labels(client: &DbClient, session_id: i32, labels: Vec<NewTimeLabel>) -> Result<(), sqlx::Error> {
+    if labels.is_empty() {
+        info!("Skipping insert - no labels to insert");
+        return Ok(());
+    }
+
+    let mut query_builder = sqlx::QueryBuilder::new(
+        "INSERT INTO time_labels (session_id, start_timestamp, end_timestamp, label, color) "
+    );
+
+    query_builder.push_values(labels.iter(), |mut b, label| {
+        b.push_bind(session_id)
+            .push_bind(label.start_timestamp)
+            .push_bind(label.end_timestamp)
+            .push_bind(&label.label)
+            .push_bind(&label.color);
+    });
+
+    query_builder.build().execute(&**client).await?;
+    info!("Inserted {} time labels for session {}", labels.len(), session_id);
+    Ok(())
+}
+
+/// Get EEG data rows for a given session within a time range.
+///
+/// Returns all rows from eeg_data where session_id matches and time is between
+/// start and end (inclusive), ordered by time.
+pub async fn get_eeg_data_by_range(client: &DbClient, session_id: i32, start: DateTime<Utc>, end: DateTime<Utc>) -> Result<Vec<EegDataRow>, Error> {
+    info!("Retrieving EEG data for session {} from {} to {}", session_id, start, end);
+
+    let data = sqlx::query_as!(
+        EegDataRow,
+        "SELECT time, channel1, channel2, channel3, channel4 FROM eeg_data WHERE session_id = $1 AND time >= $2 AND time <= $3 ORDER BY time",
+        session_id,
+        start,
+        end,
+    )
+    .fetch_all(&**client)
+    .await?;
+
+    info!("Retrieved {} EEG data rows.", data.len());
+    Ok(data)
+}
+
+/// Get time labels for a given session within a time range.
+///
+/// Returns all rows from time_labels where session_id matches and timestamp is between
+/// start and end (inclusive), ordered by timestamp.
+pub async fn get_time_labels_by_range(client: &DbClient, session_id: i32, start: DateTime<Utc>, end: DateTime<Utc>) -> Result<Vec<TimeLabel>, Error> {
+    info!("Retrieving time labels for session {} from {} to {}", session_id, start, end);
+
+    let labels = sqlx::query_as!(
+        TimeLabel,
+        "SELECT id, session_id, start_timestamp, end_timestamp, label, color FROM time_labels WHERE session_id = $1 AND start_timestamp >= $2 AND start_timestamp <= $3 ORDER BY start_timestamp",
+        session_id,
+        start,
+        end,
+    )
+    .fetch_all(&**client)
+    .await?;
+
+    info!("Retrieved {} time labels.", labels.len());
+    Ok(labels)
 }
 
 /// Export the EEG data for a given session ID and time range as a CSV string.

--- a/backend/shared-logic/src/models.rs
+++ b/backend/shared-logic/src/models.rs
@@ -53,3 +53,41 @@ pub struct FrontendState {
     pub data: Value, 
     pub updated_at: chrono::DateTime<Utc>,
 }
+
+// Struct for a time label row coming OUT of the DB (includes all columns)
+#[derive(Debug, Serialize, Deserialize, sqlx::FromRow)]
+pub struct TimeLabel {
+    pub id: i32,
+    pub session_id: i32,
+    pub start_timestamp: DateTime<Utc>,
+    pub end_timestamp: Option<DateTime<Utc>>,
+    pub label: String,
+    pub color: String,
+}
+
+// Struct for a time label coming INTO the API from the frontend
+// No id (auto-generated) or session_id (comes from URL path)
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NewTimeLabel {
+    pub start_timestamp: DateTime<Utc>,
+    pub end_timestamp: Option<DateTime<Utc>>,
+    pub label: String,
+    pub color: String,
+}
+
+// Struct for a row of EEG data coming OUT of the DB
+#[derive(Debug, Serialize, Deserialize, sqlx::FromRow)]
+pub struct EegDataRow {
+    pub time: DateTime<Utc>,
+    pub channel1: i32,
+    pub channel2: i32,
+    pub channel3: i32,
+    pub channel4: i32,
+}
+
+// Struct for the query parameters on GET /api/sessions/{session_id}/eeg-data
+#[derive(Debug, Deserialize)]
+pub struct EegDataQuery {
+    pub start: DateTime<Utc>,
+    pub end: DateTime<Utc>,
+}

--- a/backend/websocket-server/Dockerfile
+++ b/backend/websocket-server/Dockerfile
@@ -28,6 +28,9 @@ COPY .sqlx ./.sqlx
 # Copy shared-logic source (it's a library used by both servers)
 COPY shared-logic/src ./shared-logic/src
 
+# Copy patched lsl crate to override the broken crates.io version
+COPY lsl-patched ./lsl-patched
+
 # Create dummy main.rs files for workspace members to cache dependencies
 # IMPORTANT: Use async main with tokio macro since the real code uses #[tokio::main]
 RUN mkdir -p websocket-server/src api-server/src && \

--- a/frontend/app/api/sessions/[session_id]/eeg-data/route.ts
+++ b/frontend/app/api/sessions/[session_id]/eeg-data/route.ts
@@ -1,0 +1,19 @@
+import { forwardToBackend, passthroughJsonResponse } from '@/lib/backend-proxy';
+
+export async function GET(
+    req: Request,
+    context: {
+        params: { session_id: string } | Promise<{ session_id: string }>;
+    }
+) {
+    const params = await Promise.resolve(context.params);
+    const requestUrl = new URL(req.url);
+    const search = requestUrl.search;
+
+    const response = await forwardToBackend({
+        method: 'GET',
+        path: `/api/sessions/${params.session_id}/eeg-data${search}`,
+    });
+
+    return passthroughJsonResponse(response);
+}

--- a/frontend/app/api/sessions/[session_id]/time-label/route.ts
+++ b/frontend/app/api/sessions/[session_id]/time-label/route.ts
@@ -1,0 +1,37 @@
+import { forwardToBackend, passthroughJsonResponse } from '@/lib/backend-proxy';
+
+export async function GET(
+    req: Request,
+    context: {
+        params: { session_id: string } | Promise<{ session_id: string }>;
+    }
+) {
+    const params = await Promise.resolve(context.params);
+    const requestUrl = new URL(req.url);
+    const search = requestUrl.search;
+
+    const response = await forwardToBackend({
+        method: 'GET',
+        path: `/api/sessions/${params.session_id}/time-label${search}`,
+    });
+
+    return passthroughJsonResponse(response);
+}
+
+export async function POST(
+    req: Request,
+    context: {
+        params: { session_id: string } | Promise<{ session_id: string }>;
+    }
+) {
+    const params = await Promise.resolve(context.params);
+    const body = await req.text();
+
+    const response = await forwardToBackend({
+        method: 'POST',
+        path: `/api/sessions/${params.session_id}/time-label`,
+        body,
+    });
+
+    return passthroughJsonResponse(response);
+}

--- a/frontend/components/nodes/artifact-node/artifact-node.tsx
+++ b/frontend/components/nodes/artifact-node/artifact-node.tsx
@@ -27,6 +27,7 @@ export default function ArtifactNode({ id, data }: ArtifactNodeProps) {
             selectedArtifacts,
             intensity,
         });
+        window.dispatchEvent(new Event('node-config-changed'));
     }, [id, mode, selectedArtifacts, intensity, reactFlowInstance]);
 
     const checkConnectionStatus = React.useCallback(() => {

--- a/frontend/components/nodes/filter-node/filter-node.tsx
+++ b/frontend/components/nodes/filter-node/filter-node.tsx
@@ -83,6 +83,7 @@ export default function FilterNode({ id, data }: FilterNodeProps) {
                 n.id === id ? { ...n, data: { ...n.data, config, _highCutoff: highCutoff, _lowCutoff: lowCutoff, _selectedFilter: selectedFilter } } : n
             )
         );
+        window.dispatchEvent(new Event('node-config-changed'));
     }, [id, reactFlowInstance, selectedFilter, lowCutoff, highCutoff, isConnected]);
 
 

--- a/frontend/components/nodes/label-node/label-combo-box.tsx
+++ b/frontend/components/nodes/label-node/label-combo-box.tsx
@@ -1,0 +1,207 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import LabelTimelinePanel, {
+    LabelGraphPoint,
+    TimelineLabelRow,
+} from '@/components/nodes/label-node/label-timeline-panel';
+
+export type LabelColor = 'teal-700' | 'teal-500' | 'teal-300' | 'mint-100';
+
+interface ComboBoxProps {
+    isConnected?: boolean;
+    isDataStreamOn?: boolean;
+    isTriggerActive: boolean;
+    onTriggerClick: () => void;
+    onPreviewOpen: () => void;
+    isExpanded: boolean;
+    onExpandedClose: () => void;
+    onGraphViewClick: () => void;
+    onTimelineViewClick: () => void;
+    viewMode: 'timeline' | 'graph';
+    isLabelPopupOpen: boolean;
+    labelInputValue: string;
+    selectedColor: LabelColor;
+    onLabelInputChange: (value: string) => void;
+    onColorSelect: (color: LabelColor) => void;
+    onConfirmLabel: () => void;
+    onCloseLabelPopup: () => void;
+    timelineRows: TimelineLabelRow[];
+    graphData: LabelGraphPoint[];
+    sessionStartTimestamp: string | null;
+    latestBackendTimestamp: string | null;
+}
+
+export const colorClassMap: Record<LabelColor, string> = {
+    'teal-700': 'bg-[#2E7B75]',
+    'teal-500': 'bg-[#6CAFA4]',
+    'teal-300': 'bg-[#98CDBF]',
+    'mint-100': 'bg-[#D6E6D4]',
+};
+
+export default function ComboBox({
+    isConnected = false,
+    isDataStreamOn = false,
+    isTriggerActive,
+    onTriggerClick,
+    onPreviewOpen,
+    isExpanded,
+    onExpandedClose,
+    onGraphViewClick,
+    onTimelineViewClick,
+    viewMode,
+    isLabelPopupOpen,
+    labelInputValue,
+    selectedColor,
+    onLabelInputChange,
+    onColorSelect,
+    onConfirmLabel,
+    onCloseLabelPopup,
+    timelineRows,
+    graphData,
+    sessionStartTimestamp,
+    latestBackendTimestamp,
+}: ComboBoxProps) {
+    return (
+        <div
+            className={cn(
+                'bg-white rounded-[30px] border-2 overflow-hidden border-[#D3D3D3]'
+            )}
+            style={{
+                width: isExpanded ? '760px' : 'fit-content',
+                minWidth: isExpanded ? '760px' : '396px',
+            }}
+        >
+            <div className="w-full h-[70px] px-4 flex items-center justify-between transition-colors">
+                <div className="flex items-center">
+                    <div
+                        className={cn(
+                            'absolute left-6 w-6 h-6 rounded-full border-[3px] flex items-center justify-center bg-white',
+                            isConnected ? 'border-black' : 'border-gray-300'
+                        )}
+                    />
+
+                    {/* Status dot */}
+                    <div
+                        className={cn(
+                            'absolute left-16 w-3 h-3 rounded-full',
+                            isConnected && isDataStreamOn
+                                ? 'bg-[#509693]'
+                                : 'bg-[#D3D3D3]'
+                        )}
+                    />
+
+                    <span className="absolute left-24 font-geist text-[25px] font-[550] leading-tight text-black tracking-wider">
+                        Labeling Node
+                    </span>
+                </div>
+
+                <div className="flex items-center">
+                    <div
+                        className={cn(
+                            'absolute right-6 w-6 h-6 rounded-full border-[3px] flex items-center justify-center bg-white',
+                            isConnected ? 'border-black' : 'border-gray-300'
+                        )}
+                    />
+                </div>
+            </div>
+
+            {/* Trigger and Preview buttons */}
+            <div className="flex flex-col items-center gap-2 pb-3">
+                <span className="text-[24px] leading-none text-black">
+                    {isTriggerActive ? 'Stop labeling' : 'Start labeling'}
+                </span>
+
+                <div className="flex items-center gap-3">
+                    <button
+                        className={cn(
+                            'nodrag nopan mt-1 text-lg px-3 py-1 rounded-md border transition-colors',
+                            isTriggerActive
+                                ? 'bg-red-500 text-white border-red-500'
+                                : 'bg-[#2E7B75] text-white border-[#2E7B75]'
+                        )}
+                        onClick={onTriggerClick}
+                    >
+                        Trigger
+                    </button>
+
+                    <button
+                        className="nodrag nopan mt-1 text-lg px-2 py-1 rounded-md text-black hover:text-[#2E7B75] transition-colors"
+                        onClick={onPreviewOpen}
+                    >
+                        Preview ↗
+                    </button>
+                </div>
+            </div>
+
+            {isLabelPopupOpen && (
+                <div className="mx-5 mb-4 rounded-[18px] border border-[#D3D3D3] bg-white p-3">
+                    <div className="mb-1 flex items-center justify-between">
+                        <span className="text-sm text-black">Name</span>
+                        <button
+                            className="nodrag nopan text-[#BFBFBF] hover:text-[#8F8F8F] transition-colors"
+                            onClick={onCloseLabelPopup}
+                            aria-label="Close label popup"
+                        >
+                            ×
+                        </button>
+                    </div>
+
+                    <input
+                        type="text"
+                        value={labelInputValue}
+                        onChange={(event) => onLabelInputChange(event.target.value)}
+                        placeholder="Enter label here"
+                        className="nodrag nopan w-full rounded-md border border-[#E2E2E2] px-2 py-1 text-sm outline-none focus:ring-2 focus:ring-[#6CAFA4]"
+                    />
+
+                    <div className="mt-3 flex items-center justify-between">
+                        <span className="text-sm text-black">Color</span>
+
+                        <div className="flex items-center gap-4">
+                            {(Object.keys(colorClassMap) as LabelColor[]).map((color) => {
+                                const isSelected = color === selectedColor;
+                                return (
+                                    <button
+                                        key={color}
+                                        className={cn(
+                                            'nodrag nopan h-3.5 w-3.5 rounded-full transition-all',
+                                            colorClassMap[color],
+                                            isSelected
+                                                ? 'ring-2 ring-offset-2 ring-[#2E7B75]'
+                                                : 'ring-0'
+                                        )}
+                                        onClick={() => onColorSelect(color)}
+                                        aria-label={`Select ${color} label color`}
+                                    />
+                                );
+                            })}
+                        </div>
+                    </div>
+
+                    <div className="mt-3 flex justify-end">
+                        <button
+                            className="nodrag nopan rounded-md px-3 py-1 text-sm transition-colors bg-[#2E7B75] text-white hover:opacity-90"
+                            onClick={onConfirmLabel}
+                        >
+                            Confirm
+                        </button>
+                    </div>
+                </div>
+            )}
+
+            <LabelTimelinePanel
+                isExpanded={isExpanded}
+                rows={timelineRows}
+                sessionStartTimestamp={sessionStartTimestamp}
+                latestBackendTimestamp={latestBackendTimestamp}
+                onClose={onExpandedClose}
+                onGraphViewClick={onGraphViewClick}
+                onTimelineViewClick={onTimelineViewClick}
+                viewMode={viewMode}
+                isConnected={isConnected}
+                isDataStreamOn={isDataStreamOn}
+                graphData={graphData}
+            />
+        </div>
+    );
+}

--- a/frontend/components/nodes/label-node/label-combo-box.tsx
+++ b/frontend/components/nodes/label-node/label-combo-box.tsx
@@ -121,7 +121,7 @@ export default function ComboBox({
                                 className={cn(
                                     'nodrag nopan text-lg px-4 py-1 rounded-md border transition-colors',
                                     isTriggerActive
-                                        ? 'bg-white text-black border-black'
+                                        ? 'bg-white text-[#2E7B75] border-[#2E7B75]'
                                         : 'bg-[#2E7B75] text-white border-[#2E7B75]'
                                 )}
                                 onClick={onTriggerClick}

--- a/frontend/components/nodes/label-node/label-combo-box.tsx
+++ b/frontend/components/nodes/label-node/label-combo-box.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { ArrowUpRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import LabelTimelinePanel, {
     LabelGraphPoint,
@@ -29,6 +30,7 @@ interface ComboBoxProps {
     graphData: LabelGraphPoint[];
     sessionStartTimestamp: string | null;
     latestBackendTimestamp: string | null;
+    fetchDataForLabel?: (start: string, end: string) => Promise<LabelGraphPoint[]>;
 }
 
 export const colorClassMap: Record<LabelColor, string> = {
@@ -60,6 +62,7 @@ export default function ComboBox({
     graphData,
     sessionStartTimestamp,
     latestBackendTimestamp,
+    fetchDataForLabel,
 }: ComboBoxProps) {
     return (
         <div
@@ -71,67 +74,75 @@ export default function ComboBox({
                 minWidth: isExpanded ? '760px' : '396px',
             }}
         >
-            <div className="w-full h-[70px] px-4 flex items-center justify-between transition-colors">
-                <div className="flex items-center">
-                    <div
-                        className={cn(
-                            'absolute left-6 w-6 h-6 rounded-full border-[3px] flex items-center justify-center bg-white',
-                            isConnected ? 'border-black' : 'border-gray-300'
-                        )}
-                    />
+            {!isExpanded && (
+                <>
+                    <div className="w-full h-[70px] px-4 flex items-center justify-between transition-colors">
+                        <div className="flex items-center">
+                            <span
+                                className={cn(
+                                    'absolute left-6 w-6 h-6 rounded-full flex items-center justify-center border-[3px]',
+                                    isConnected ? 'border-black' : 'border-[#D3D3D3]'
+                                )}
+                            >
+                                {isConnected && <span className="w-3 h-3 rounded-full bg-white" />}
+                            </span>
 
-                    {/* Status dot */}
-                    <div
-                        className={cn(
-                            'absolute left-16 w-3 h-3 rounded-full',
-                            isConnected && isDataStreamOn
-                                ? 'bg-[#509693]'
-                                : 'bg-[#D3D3D3]'
-                        )}
-                    />
+                            {/* Status dot */}
+                            <div
+                                className={cn(
+                                    'absolute left-16 w-3 h-3 rounded-full',
+                                    isConnected && isDataStreamOn
+                                        ? 'bg-[#509693]'
+                                        : 'bg-[#D3D3D3]'
+                                )}
+                            />
 
-                    <span className="absolute left-24 font-geist text-[25px] font-[550] leading-tight text-black tracking-wider">
-                        Labeling Node
-                    </span>
-                </div>
+                            <span className="absolute left-24 font-geist text-[25px] font-[550] leading-tight text-black tracking-wider">
+                                Labeling Node
+                            </span>
+                        </div>
 
-                <div className="flex items-center">
-                    <div
-                        className={cn(
-                            'absolute right-6 w-6 h-6 rounded-full border-[3px] flex items-center justify-center bg-white',
-                            isConnected ? 'border-black' : 'border-gray-300'
-                        )}
-                    />
-                </div>
-            </div>
+                        <div className="flex items-center">
+                            <span
+                                className={cn(
+                                    'absolute right-6 w-6 h-6 rounded-full flex items-center justify-center border-[3px]',
+                                    isConnected ? 'border-black' : 'border-[#D3D3D3]'
+                                )}
+                            >
+                                {isConnected && <span className="w-3 h-3 rounded-full bg-white" />}
+                            </span>
+                        </div>
+                    </div>
 
-            {/* Trigger and Preview buttons */}
-            <div className="flex flex-col items-center gap-2 pb-3">
-                <span className="text-[24px] leading-none text-black">
-                    {isTriggerActive ? 'Stop labeling' : 'Start labeling'}
-                </span>
+                    {/* Trigger and Preview buttons */}
+                    <div className="flex flex-col items-center gap-1 pb-4">
+                        <div className="flex items-center gap-3">
+                            <button
+                                className={cn(
+                                    'nodrag nopan text-lg px-4 py-1 rounded-md border transition-colors',
+                                    isTriggerActive
+                                        ? 'bg-white text-black border-black'
+                                        : 'bg-[#2E7B75] text-white border-[#2E7B75]'
+                                )}
+                                onClick={onTriggerClick}
+                            >
+                                Trigger
+                            </button>
 
-                <div className="flex items-center gap-3">
-                    <button
-                        className={cn(
-                            'nodrag nopan mt-1 text-lg px-3 py-1 rounded-md border transition-colors',
-                            isTriggerActive
-                                ? 'bg-red-500 text-white border-red-500'
-                                : 'bg-[#2E7B75] text-white border-[#2E7B75]'
-                        )}
-                        onClick={onTriggerClick}
-                    >
-                        Trigger
-                    </button>
+                            <button
+                                className="nodrag nopan text-lg px-2 py-1 rounded-md text-black hover:text-[#2E7B75] transition-colors"
+                                onClick={onPreviewOpen}
+                            >
+                                Preview <ArrowUpRight size={16} className="inline ml-1" />
+                            </button>
+                        </div>
 
-                    <button
-                        className="nodrag nopan mt-1 text-lg px-2 py-1 rounded-md text-black hover:text-[#2E7B75] transition-colors"
-                        onClick={onPreviewOpen}
-                    >
-                        Preview ↗
-                    </button>
-                </div>
-            </div>
+                        <span className="text-[18px] leading-none text-black mt-1">
+                            {isTriggerActive ? 'Stop labeling' : 'Start labeling'}
+                        </span>
+                    </div>
+                </>
+            )}
 
             {isLabelPopupOpen && (
                 <div className="mx-5 mb-4 rounded-[18px] border border-[#D3D3D3] bg-white p-3">
@@ -157,22 +168,37 @@ export default function ComboBox({
                     <div className="mt-3 flex items-center justify-between">
                         <span className="text-sm text-black">Color</span>
 
-                        <div className="flex items-center gap-4">
+                        <div className="flex items-center gap-3">
                             {(Object.keys(colorClassMap) as LabelColor[]).map((color) => {
                                 const isSelected = color === selectedColor;
                                 return (
                                     <button
                                         key={color}
                                         className={cn(
-                                            'nodrag nopan h-3.5 w-3.5 rounded-full transition-all',
-                                            colorClassMap[color],
-                                            isSelected
-                                                ? 'ring-2 ring-offset-2 ring-[#2E7B75]'
-                                                : 'ring-0'
+                                            'nodrag nopan h-5 w-5 rounded-full flex items-center justify-center transition-all',
+                                            colorClassMap[color]
                                         )}
                                         onClick={() => onColorSelect(color)}
                                         aria-label={`Select ${color} label color`}
-                                    />
+                                    >
+                                        {isSelected && (
+                                            <svg
+                                                width="10"
+                                                height="8"
+                                                viewBox="0 0 10 8"
+                                                fill="none"
+                                                xmlns="http://www.w3.org/2000/svg"
+                                            >
+                                                <path
+                                                    d="M1 3.5L3.5 6.5L9 1"
+                                                    stroke="white"
+                                                    strokeWidth="1.5"
+                                                    strokeLinecap="round"
+                                                    strokeLinejoin="round"
+                                                />
+                                            </svg>
+                                        )}
+                                    </button>
                                 );
                             })}
                         </div>
@@ -201,6 +227,7 @@ export default function ComboBox({
                 isConnected={isConnected}
                 isDataStreamOn={isDataStreamOn}
                 graphData={graphData}
+                fetchDataForLabel={fetchDataForLabel}
             />
         </div>
     );

--- a/frontend/components/nodes/label-node/label-combo-box.tsx
+++ b/frontend/components/nodes/label-node/label-combo-box.tsx
@@ -24,6 +24,7 @@ interface ComboBoxProps {
     selectedColor: LabelColor;
     onLabelInputChange: (value: string) => void;
     onColorSelect: (color: LabelColor) => void;
+    labelError?: string | null;
     onConfirmLabel: () => void;
     onCloseLabelPopup: () => void;
     timelineRows: TimelineLabelRow[];
@@ -56,6 +57,7 @@ export default function ComboBox({
     selectedColor,
     onLabelInputChange,
     onColorSelect,
+    labelError,
     onConfirmLabel,
     onCloseLabelPopup,
     timelineRows,
@@ -162,8 +164,14 @@ export default function ComboBox({
                         value={labelInputValue}
                         onChange={(event) => onLabelInputChange(event.target.value)}
                         placeholder="Enter label here"
-                        className="nodrag nopan w-full rounded-md border border-[#E2E2E2] px-2 py-1 text-sm outline-none focus:ring-2 focus:ring-[#6CAFA4]"
+                        className={cn(
+                            'nodrag nopan w-full rounded-md border px-2 py-1 text-sm outline-none focus:ring-2 focus:ring-[#6CAFA4]',
+                            labelError ? 'border-red-400' : 'border-[#E2E2E2]'
+                        )}
                     />
+                    {labelError && (
+                        <p className="mt-1 text-xs text-red-500">{labelError}</p>
+                    )}
 
                     <div className="mt-3 flex items-center justify-between">
                         <span className="text-sm text-black">Color</span>

--- a/frontend/components/nodes/label-node/label-node.tsx
+++ b/frontend/components/nodes/label-node/label-node.tsx
@@ -21,7 +21,6 @@ interface LabeledMoment {
     source: 'Trigger';
 }
 
-const LABEL_SESSION_ID = process.env.NEXT_PUBLIC_LABEL_SESSION_ID ?? '1';
 
 function normalizeNodeTimestamp(raw: unknown): string | null {
     if (raw == null) return null;
@@ -100,7 +99,7 @@ export default function LabelNode({ id }: LabelNodeProps) {
             return;
         }
         if (isConnected) {
-            void createSession('Label Session').then((session) => {
+            void createSession(`Label Session ${new Date().toISOString()}`).then((session) => {
                 setSessionIdSentToBackend(session.id);
             });
         }

--- a/frontend/components/nodes/label-node/label-node.tsx
+++ b/frontend/components/nodes/label-node/label-node.tsx
@@ -1,0 +1,419 @@
+'use client';
+
+import React from 'react';
+import { Handle, Position, useReactFlow } from '@xyflow/react';
+import { useGlobalContext } from '@/context/GlobalContext';
+import useNodeData from '@/hooks/useNodeData';
+import ComboBox, { LabelColor } from './label-combo-box';
+import { LabelGraphPoint, TimelineLabelRow } from '@/components/nodes/label-node/label-timeline-panel';
+import { saveTimeLabels, getSessions, createSession } from '@/lib/session-api';
+
+interface LabelNodeProps {
+    id?: string;
+}
+
+interface LabeledMoment {
+    id: string;
+    label: string;
+    color: LabelColor;
+    startTimestamp: string;
+    endTimestamp: string;
+    source: 'Trigger';
+}
+
+const LABEL_SESSION_ID = process.env.NEXT_PUBLIC_LABEL_SESSION_ID ?? '1';
+
+function normalizeNodeTimestamp(raw: unknown): string | null {
+    if (raw == null) return null;
+
+    if (typeof raw === 'number' && Number.isFinite(raw)) {
+        const epochMs = raw < 1_000_000_000_000 ? raw * 1000 : raw;
+        return new Date(epochMs).toISOString();
+    }
+
+    const value = String(raw).trim();
+    if (!value) return null;
+
+    if (/^\d+$/.test(value)) {
+        const numeric = Number(value);
+        if (!Number.isFinite(numeric)) return null;
+        const epochMs = value.length <= 10 ? numeric * 1000 : numeric;
+        return new Date(epochMs).toISOString();
+    }
+
+    const parsed = Date.parse(value);
+    if (!Number.isNaN(parsed)) {
+        return new Date(parsed).toISOString();
+    }
+
+    const timeOnlyMatch = value.match(
+        /^(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,3}))?$/
+    );
+    if (!timeOnlyMatch) return null;
+
+    const hours = Number(timeOnlyMatch[1]);
+    const minutes = Number(timeOnlyMatch[2]);
+    const seconds = Number(timeOnlyMatch[3]);
+    const milliseconds = Number(
+        (timeOnlyMatch[4] ?? '0').padEnd(3, '0').slice(0, 3)
+    );
+
+    const date = new Date();
+    date.setHours(hours, minutes, seconds, milliseconds);
+    return date.toISOString();
+}
+
+export default function LabelNode({ id }: LabelNodeProps) {
+    const [isConnected, setIsConnected] = React.useState(false);
+    const [isTriggerActive, setIsTriggerActive] = React.useState(false);
+    const [isExpanded, setIsExpanded] = React.useState(false);
+    const [viewMode, setViewMode] = React.useState<'timeline' | 'graph'>(
+        'timeline'
+    );
+    const [isLabelPopupOpen, setIsLabelPopupOpen] = React.useState(false);
+    const [labelInputValue, setLabelInputValue] = React.useState('');
+    const [selectedColor, setSelectedColor] = React.useState<LabelColor>('teal-700');
+    const [sessionStartTimestamp, setSessionStartTimestamp] = React.useState<string | null>(null);
+    const [latestBackendTimestamp, setLatestBackendTimestamp] = React.useState<
+        string | null
+    >(null);
+    const [activeStartTimestamp, setActiveStartTimestamp] = React.useState<
+        string | null
+    >(null);
+    const [pendingEndTimestamp, setPendingEndTimestamp] = React.useState<string | null>(null);
+    const [labeledMoments, setLabeledMoments] = React.useState<LabeledMoment[]>([]);
+    const labelsRef = React.useRef<LabeledMoment[]>([]);
+    const sentLabelIdsRef = React.useRef<Set<string>>(new Set());
+    const previousStreamStateRef = React.useRef(false);
+    const momentCounterRef = React.useRef(0);
+
+    const { dataStreaming } = useGlobalContext();
+    const { renderData } = useNodeData(300, 15);
+
+    const [sessionIdSentToBackend, setSessionIdSentToBackend] = React.useState<number | null>(null);
+
+    const reactFlowInstance = useReactFlow();
+
+    React.useEffect(() => {
+        // when the thing is connected for the first time, send the session id to the backend
+        if (sessionIdSentToBackend !== null) {
+            return;
+        }
+        if (isConnected) {
+            void createSession('Label Session').then((session) => {
+                setSessionIdSentToBackend(session.id);
+            });
+        }
+    }, [isConnected]);
+
+    const checkConnectionStatus = React.useCallback(() => {
+        try {
+            const edges = reactFlowInstance.getEdges();
+            const nodes = reactFlowInstance.getNodes();
+
+            // Check if this node is connected to source node or any activated node
+            const isConnectedToActivatedNode = (nodeId: string, visited: Set<string> = new Set()): boolean => {
+                if (visited.has(nodeId)) return false; // Prevent infinite loops
+                visited.add(nodeId);
+
+                // Find incoming edges to this node
+                const incomingEdges = edges.filter(edge => edge.target === nodeId);
+
+                for (const edge of incomingEdges) {
+                    const sourceNode = nodes.find(n => n.id === edge.source);
+                    if (!sourceNode) continue;
+
+                    // If source is a source-node, we're activated
+                    if (sourceNode.type === 'source-node') {
+                        return true;
+                    }
+
+                    // If source is another node, check if it's activated
+                    if (sourceNode.id && isConnectedToActivatedNode(sourceNode.id, visited)) {
+                        return true;
+                    }
+                }
+
+                return false;
+            };
+
+            const isActivated = id ? isConnectedToActivatedNode(id) : false;
+            setIsConnected(isActivated);
+        } catch (error) {
+            console.error('Error checking connection:', error);
+            setIsConnected(false);
+        }
+    }, [id, reactFlowInstance]);
+
+    React.useEffect(() => {
+        checkConnectionStatus();
+
+        const handleEdgeChange = () => {
+            checkConnectionStatus();
+        };
+
+        window.addEventListener('reactflow-edges-changed', handleEdgeChange);
+
+        const interval = setInterval(checkConnectionStatus, 1000);
+
+        return () => {
+            window.removeEventListener('reactflow-edges-changed', handleEdgeChange);
+            clearInterval(interval);
+        };
+    }, [checkConnectionStatus]);
+
+    React.useEffect(() => {
+        labelsRef.current = labeledMoments;
+    }, [labeledMoments]);
+
+    React.useEffect(() => {
+        if (!dataStreaming || renderData.length === 0) {
+            return;
+        }
+
+        const mostRecentPoint = renderData[renderData.length - 1];
+        const timestamp = normalizeNodeTimestamp(mostRecentPoint.time);
+
+        if (!timestamp) {
+            return;
+        }
+
+        setSessionStartTimestamp((previousValue) => previousValue ?? timestamp);
+        setLatestBackendTimestamp(timestamp);
+    }, [dataStreaming, renderData]);
+
+    const postLabelsToApi = React.useCallback(async () => {
+        const unsentLabels = labelsRef.current.filter(
+            (moment) => !sentLabelIdsRef.current.has(moment.id)
+        );
+        // does it make more sense to keep track of index?
+
+        if (unsentLabels.length === 0) {
+            return;
+        }
+
+        // TODO: should these be sent in number format?
+        const payload = unsentLabels.map((moment) => ({
+            timestamp: moment.startTimestamp, // will need start and end timestamps, backend update
+            label: moment.label,
+        }));
+
+        // first, get session ids from backend
+        const sessionId = await getSessions();
+        console.log('Session ids:', sessionId);
+
+        if (sessionIdSentToBackend === null) {
+            console.error('Session id not sent to backend');
+            return;
+        }
+
+        void saveTimeLabels(sessionIdSentToBackend, payload).then(() => {
+            console.log('POST time labels:', payload);
+        });
+    }, [sessionIdSentToBackend]);
+
+    React.useEffect(() => {
+        const wasStreaming = previousStreamStateRef.current;
+        const streamJustStopped = wasStreaming && !dataStreaming;
+
+        if (streamJustStopped) {
+            if (isTriggerActive) {
+                setIsTriggerActive(false);
+                setActiveStartTimestamp(null);
+                setPendingEndTimestamp(null);
+                setIsLabelPopupOpen(false);
+                setLabelInputValue('');
+            }
+            void postLabelsToApi();
+        }
+
+        previousStreamStateRef.current = dataStreaming;
+    }, [dataStreaming, isTriggerActive, postLabelsToApi]);
+
+    const handleTriggerClick = () => {
+        if (!dataStreaming) {
+            console.warn('Cannot label while data stream is stopped.');
+            return;
+        }
+
+        if (!isTriggerActive) {
+            if (!latestBackendTimestamp) {
+                console.warn('No backend EEG timestamp available yet for label start.');
+                return;
+            }
+
+            setActiveStartTimestamp(latestBackendTimestamp);
+            setPendingEndTimestamp(null);
+            setIsTriggerActive(true);
+            return;
+        }
+
+        if (!latestBackendTimestamp) {
+            console.warn('No backend EEG timestamp available yet for label end.');
+            return;
+        }
+
+        setPendingEndTimestamp(latestBackendTimestamp);
+        setIsTriggerActive(false);
+        setIsLabelPopupOpen(true);
+    };
+
+    const handleCloseLabelPopup = () => {
+        setIsLabelPopupOpen(false);
+        setLabelInputValue('');
+        setActiveStartTimestamp(null);
+        setPendingEndTimestamp(null);
+        setIsTriggerActive(false);
+    };
+
+    const handleConfirmLabel = () => {
+        if (!activeStartTimestamp || !pendingEndTimestamp) {
+            console.warn('Missing backend timestamps for labeled moment.');
+            return;
+        }
+
+        momentCounterRef.current += 1;
+
+        const newLabeledMoment: LabeledMoment = {
+            id: `moment-${momentCounterRef.current}`,
+            label: labelInputValue.trim() || 'Untitled',
+            color: selectedColor,
+            startTimestamp: activeStartTimestamp,
+            endTimestamp: pendingEndTimestamp,
+            source: 'Trigger',
+        };
+
+        setLabeledMoments((prev) => [...prev, newLabeledMoment]);
+        setIsLabelPopupOpen(false);
+        setLabelInputValue('');
+        setActiveStartTimestamp(null);
+        setPendingEndTimestamp(null);
+    };
+
+    const handlePreviewOpen = () => {
+        setIsExpanded(true);
+        setViewMode('timeline');
+    };
+
+    const handleExpandedClose = () => {
+        setIsExpanded(false);
+        setViewMode('timeline');
+    };
+
+    const handleGraphViewClick = () => {
+        setViewMode('graph');
+    };
+
+    const handleTimelineViewClick = () => {
+        setViewMode('timeline');
+    };
+
+    const timelineRows = React.useMemo<TimelineLabelRow[]>(() => {
+        const completedRows: TimelineLabelRow[] = labeledMoments.map((moment) => ({
+            id: moment.id,
+            label: moment.label,
+            color: moment.color,
+            startTimestamp: moment.startTimestamp,
+            endTimestamp: moment.endTimestamp,
+            source: moment.source,
+            isInProgress: false,
+        }));
+
+        if (isTriggerActive && activeStartTimestamp) {
+            completedRows.push({
+                id: 'active-label-row',
+                label: labelInputValue.trim() || 'Untitled',
+                color: selectedColor,
+                startTimestamp: activeStartTimestamp,
+                endTimestamp: null,
+                source: 'Trigger',
+                isInProgress: true,
+            });
+        }
+
+        return completedRows;
+    }, [activeStartTimestamp, isTriggerActive, labelInputValue, labeledMoments, selectedColor]);
+
+    const graphData = React.useMemo<LabelGraphPoint[]>(() => {
+        return renderData
+            .map((item, index: number) => {
+                return {
+                    id: `graph-point-${index}`,
+                    time: item.time,
+                    signal1: Number(item.signal1 ?? 0),
+                    signal2: Number(item.signal2 ?? 0),
+                    signal3: Number(item.signal3 ?? 0),
+                    signal4: Number(item.signal4 ?? 0),
+                };
+            })
+            .slice(-300);
+    }, [renderData]);
+
+    return (
+        <div className="relative">
+            {/* Input Handle - positioned to align with left circle */}
+            <Handle
+                type="target"
+                position={Position.Left}
+                id="labeling-input"
+                style={{
+                    left: '24px',
+                    top: '30px',
+                    transform: 'translateY(-50%)',
+                    width: '28px',
+                    height: '28px',
+                    backgroundColor: 'transparent',
+                    border: '2px solid transparent',
+                    borderRadius: '50%',
+                    zIndex: 20,
+                    cursor: 'crosshair',
+                    pointerEvents: 'all',
+                }}
+            />
+
+            {/* Output Handle - positioned to align with right circle */}
+            <Handle
+                type="source"
+                position={Position.Right}
+                id="labeling-output"
+                style={{
+                    right: '24px',
+                    top: '30px',
+                    transform: 'translateY(-50%)',
+                    width: '28px',
+                    height: '28px',
+                    backgroundColor: 'transparent',
+                    border: '2px solid transparent',
+                    borderRadius: '50%',
+                    zIndex: 20,
+                    cursor: 'crosshair',
+                    pointerEvents: 'all',
+                }}
+            />
+
+            <ComboBox 
+                isConnected={isConnected}
+                isDataStreamOn={dataStreaming}
+                isTriggerActive={isTriggerActive}
+                onTriggerClick={handleTriggerClick}
+                onPreviewOpen={handlePreviewOpen}
+                isExpanded={isExpanded}
+                onExpandedClose={handleExpandedClose}
+                onGraphViewClick={handleGraphViewClick}
+                onTimelineViewClick={handleTimelineViewClick}
+                viewMode={viewMode}
+                isLabelPopupOpen={isLabelPopupOpen}
+                labelInputValue={labelInputValue}
+                selectedColor={selectedColor}
+                onLabelInputChange={setLabelInputValue}
+                onColorSelect={setSelectedColor}
+                onConfirmLabel={handleConfirmLabel}
+                onCloseLabelPopup={handleCloseLabelPopup}
+                timelineRows={timelineRows}
+                graphData={graphData}
+                sessionStartTimestamp={sessionStartTimestamp}
+                latestBackendTimestamp={latestBackendTimestamp}
+            />
+        </div>
+    );
+}

--- a/frontend/components/nodes/label-node/label-node.tsx
+++ b/frontend/components/nodes/label-node/label-node.tsx
@@ -6,7 +6,7 @@ import { useGlobalContext } from '@/context/GlobalContext';
 import useNodeData from '@/hooks/useNodeData';
 import ComboBox, { LabelColor } from './label-combo-box';
 import { LabelGraphPoint, TimelineLabelRow } from '@/components/nodes/label-node/label-timeline-panel';
-import { saveTimeLabels, createSession } from '@/lib/session-api';
+import { saveTimeLabels, getTimeLabels } from '@/lib/session-api';
 import { exportEEGData } from '@/lib/eeg-api';
 
 interface LabelNodeProps {
@@ -93,21 +93,37 @@ export default function LabelNode({ id }: LabelNodeProps) {
     const { dataStreaming, activeSessionId } = useGlobalContext();
     const { renderData } = useNodeData(300, 15);
 
-    const [sessionIdSentToBackend, setSessionIdSentToBackend] = React.useState<number | null>(null);
-
     const reactFlowInstance = useReactFlow();
 
+    // Load persisted labels whenever the active session changes.
+    const validColors: LabelColor[] = ['teal-700', 'teal-500', 'teal-300', 'mint-100'];
     React.useEffect(() => {
-        // when the thing is connected for the first time, send the session id to the backend
-        if (sessionIdSentToBackend !== null) {
+        if (activeSessionId === null) {
+            setLabeledMoments([]);
+            sentLabelIdsRef.current = new Set();
+            momentCounterRef.current = 0;
             return;
         }
-        if (isConnected) {
-            void createSession(`Label Session ${new Date().toISOString()}`).then((session) => {
-                setSessionIdSentToBackend(session.id);
-            });
-        }
-    }, [isConnected]);
+        getTimeLabels(activeSessionId, '1970-01-01T00:00:00Z', '2100-01-01T00:00:00Z')
+            .then((labels) => {
+                const moments: LabeledMoment[] = labels
+                    .filter((l) => l.end_timestamp !== null)
+                    .map((l) => ({
+                        id: `backend-${l.id}`,
+                        label: l.label,
+                        color: validColors.includes(l.color as LabelColor)
+                            ? (l.color as LabelColor)
+                            : 'teal-700',
+                        startTimestamp: l.start_timestamp,
+                        endTimestamp: l.end_timestamp!,
+                        source: 'Trigger' as const,
+                    }));
+                setLabeledMoments(moments);
+                sentLabelIdsRef.current = new Set(moments.map((m) => m.id));
+                momentCounterRef.current = 0;
+            })
+            .catch((e) => console.error('Failed to load time labels:', e));
+    }, [activeSessionId]);
 
     const checkConnectionStatus = React.useCallback(() => {
         try {
@@ -186,8 +202,8 @@ export default function LabelNode({ id }: LabelNodeProps) {
     }, [dataStreaming, renderData]);
 
     const postLabelsToApi = React.useCallback(async () => {
-        if (sessionIdSentToBackend === null) {
-            console.error('No session id — cannot post labels');
+        if (activeSessionId === null) {
+            console.error('No active session id — cannot post labels');
             return;
         }
 
@@ -207,13 +223,12 @@ export default function LabelNode({ id }: LabelNodeProps) {
         }));
 
         try {
-            await saveTimeLabels(sessionIdSentToBackend, payload);
+            await saveTimeLabels(activeSessionId, payload);
             unsentLabels.forEach((moment) => sentLabelIdsRef.current.add(moment.id));
-            console.log('POST time labels success:', payload);
         } catch (e) {
             console.error('Failed to POST time labels:', e);
         }
-    }, [sessionIdSentToBackend]);
+    }, [activeSessionId]);
 
     React.useEffect(() => {
         const wasStreaming = previousStreamStateRef.current;
@@ -383,7 +398,7 @@ export default function LabelNode({ id }: LabelNodeProps) {
             .map((item, index: number) => {
                 return {
                     id: `graph-point-${index}`,
-                    time: item.time,
+                    time: item.rawTime ?? item.time,
                     signal1: Number(item.signal1 ?? 0),
                     signal2: Number(item.signal2 ?? 0),
                     signal3: Number(item.signal3 ?? 0),

--- a/frontend/components/nodes/label-node/label-node.tsx
+++ b/frontend/components/nodes/label-node/label-node.tsx
@@ -84,6 +84,7 @@ export default function LabelNode({ id }: LabelNodeProps) {
     >(null);
     const [pendingEndTimestamp, setPendingEndTimestamp] = React.useState<string | null>(null);
     const [labeledMoments, setLabeledMoments] = React.useState<LabeledMoment[]>([]);
+    const [labelError, setLabelError] = React.useState<string | null>(null);
     const labelsRef = React.useRef<LabeledMoment[]>([]);
     const sentLabelIdsRef = React.useRef<Set<string>>(new Set());
     const previousStreamStateRef = React.useRef(false);
@@ -263,6 +264,7 @@ export default function LabelNode({ id }: LabelNodeProps) {
     const handleCloseLabelPopup = () => {
         setIsLabelPopupOpen(false);
         setLabelInputValue('');
+        setLabelError(null);
         setActiveStartTimestamp(null);
         setPendingEndTimestamp(null);
         setIsTriggerActive(false);
@@ -274,11 +276,19 @@ export default function LabelNode({ id }: LabelNodeProps) {
             return;
         }
 
+        const normalizedName = labelInputValue.trim() || 'Untitled';
+        const isDuplicate = labeledMoments.some((m) => m.label === normalizedName);
+        if (isDuplicate) {
+            setLabelError(`"${normalizedName}" already exists`);
+            return;
+        }
+        setLabelError(null);
+
         momentCounterRef.current += 1;
 
         const newLabeledMoment: LabeledMoment = {
             id: `moment-${momentCounterRef.current}`,
-            label: labelInputValue.trim() || 'Untitled',
+            label: normalizedName,
             color: selectedColor,
             startTimestamp: activeStartTimestamp,
             endTimestamp: pendingEndTimestamp,
@@ -405,25 +415,6 @@ export default function LabelNode({ id }: LabelNodeProps) {
                 }}
             />
 
-            {/* Output Handle - positioned to align with right circle */}
-            <Handle
-                type="source"
-                position={Position.Right}
-                id="labeling-output"
-                style={{
-                    right: '24px',
-                    top: '30px',
-                    transform: 'translateY(-50%)',
-                    width: '28px',
-                    height: '28px',
-                    backgroundColor: 'transparent',
-                    border: '2px solid transparent',
-                    borderRadius: '50%',
-                    zIndex: 20,
-                    cursor: 'crosshair',
-                    pointerEvents: 'all',
-                }}
-            />
 
             <ComboBox 
                 isConnected={isConnected}
@@ -439,8 +430,9 @@ export default function LabelNode({ id }: LabelNodeProps) {
                 isLabelPopupOpen={isLabelPopupOpen}
                 labelInputValue={labelInputValue}
                 selectedColor={selectedColor}
-                onLabelInputChange={setLabelInputValue}
+                onLabelInputChange={(v) => { setLabelInputValue(v); setLabelError(null); }}
                 onColorSelect={setSelectedColor}
+                labelError={labelError}
                 onConfirmLabel={handleConfirmLabel}
                 onCloseLabelPopup={handleCloseLabelPopup}
                 timelineRows={timelineRows}

--- a/frontend/components/nodes/label-node/label-node.tsx
+++ b/frontend/components/nodes/label-node/label-node.tsx
@@ -6,7 +6,8 @@ import { useGlobalContext } from '@/context/GlobalContext';
 import useNodeData from '@/hooks/useNodeData';
 import ComboBox, { LabelColor } from './label-combo-box';
 import { LabelGraphPoint, TimelineLabelRow } from '@/components/nodes/label-node/label-timeline-panel';
-import { saveTimeLabels, createSession, getEegData } from '@/lib/session-api';
+import { saveTimeLabels, createSession } from '@/lib/session-api';
+import { exportEEGData } from '@/lib/eeg-api';
 
 interface LabelNodeProps {
     id?: string;
@@ -40,7 +41,9 @@ function normalizeNodeTimestamp(raw: unknown): string | null {
         return new Date(epochMs).toISOString();
     }
 
-    const parsed = Date.parse(value);
+    // Truncate sub-millisecond precision (e.g. nanoseconds) so Date.parse succeeds.
+    const truncated = value.replace(/(\.\d{3})\d+/, '$1');
+    const parsed = Date.parse(truncated);
     if (!Number.isNaN(parsed)) {
         return new Date(parsed).toISOString();
     }
@@ -86,7 +89,7 @@ export default function LabelNode({ id }: LabelNodeProps) {
     const previousStreamStateRef = React.useRef(false);
     const momentCounterRef = React.useRef(0);
 
-    const { dataStreaming } = useGlobalContext();
+    const { dataStreaming, activeSessionId } = useGlobalContext();
     const { renderData } = useNodeData(300, 15);
 
     const [sessionIdSentToBackend, setSessionIdSentToBackend] = React.useState<number | null>(null);
@@ -171,7 +174,7 @@ export default function LabelNode({ id }: LabelNodeProps) {
         }
 
         const mostRecentPoint = renderData[renderData.length - 1];
-        const timestamp = normalizeNodeTimestamp(mostRecentPoint.time);
+        const timestamp = normalizeNodeTimestamp(mostRecentPoint.rawTime ?? mostRecentPoint.time);
 
         if (!timestamp) {
             return;
@@ -308,21 +311,36 @@ export default function LabelNode({ id }: LabelNodeProps) {
     };
 
     const handleFetchLabelData = React.useCallback(async (start: string, end: string): Promise<LabelGraphPoint[]> => {
-        if (sessionIdSentToBackend === null) return [];
+        if (activeSessionId === null) return [];
         try {
-            const rows = await getEegData(sessionIdSentToBackend, start, end);
-            return rows.map((row, index) => ({
-                id: `fetched-${index}`,
-                time: row.time,
-                signal1: row.channel1,
-                signal2: row.channel2,
-                signal3: row.channel3,
-                signal4: row.channel4,
-            }));
+            const csv = await exportEEGData(activeSessionId, { start_time: start, end_time: end });
+            const lines = csv.trim().split('\n');
+            if (lines.length < 2) return [];
+            const header = lines[0].split(',').map((h) => h.trim().toLowerCase());
+            const timeIdx = header.findIndex((h) => h.includes('time') || h === 'timestamp');
+            const chIdxs = [0, 1, 2, 3].map((n) => {
+                const pats = [`ch${n + 1}`, `channel${n + 1}`];
+                return header.findIndex((h) => pats.includes(h));
+            });
+            if (timeIdx === -1 || chIdxs.includes(-1)) return [];
+            return lines.slice(1).flatMap((line, i) => {
+                const cols = line.trim().split(',').map((c) => c.trim());
+                if (!cols[timeIdx]) return [];
+                const vals = chIdxs.map((idx) => parseFloat(cols[idx]));
+                if (vals.some((v) => isNaN(v))) return [];
+                return [{
+                    id: `fetched-${i}`,
+                    time: cols[timeIdx],
+                    signal1: vals[0],
+                    signal2: vals[1],
+                    signal3: vals[2],
+                    signal4: vals[3],
+                }];
+            });
         } catch {
             return [];
         }
-    }, [sessionIdSentToBackend]);
+    }, [activeSessionId]);
 
     const timelineRows = React.useMemo<TimelineLabelRow[]>(() => {
         const completedRows: TimelineLabelRow[] = labeledMoments.map((moment) => ({

--- a/frontend/components/nodes/label-node/label-node.tsx
+++ b/frontend/components/nodes/label-node/label-node.tsx
@@ -6,7 +6,7 @@ import { useGlobalContext } from '@/context/GlobalContext';
 import useNodeData from '@/hooks/useNodeData';
 import ComboBox, { LabelColor } from './label-combo-box';
 import { LabelGraphPoint, TimelineLabelRow } from '@/components/nodes/label-node/label-timeline-panel';
-import { saveTimeLabels, getSessions, createSession } from '@/lib/session-api';
+import { saveTimeLabels, createSession, getEegData } from '@/lib/session-api';
 
 interface LabelNodeProps {
     id?: string;
@@ -182,33 +182,33 @@ export default function LabelNode({ id }: LabelNodeProps) {
     }, [dataStreaming, renderData]);
 
     const postLabelsToApi = React.useCallback(async () => {
+        if (sessionIdSentToBackend === null) {
+            console.error('No session id — cannot post labels');
+            return;
+        }
+
         const unsentLabels = labelsRef.current.filter(
             (moment) => !sentLabelIdsRef.current.has(moment.id)
         );
-        // does it make more sense to keep track of index?
 
         if (unsentLabels.length === 0) {
             return;
         }
 
-        // TODO: should these be sent in number format?
         const payload = unsentLabels.map((moment) => ({
-            timestamp: moment.startTimestamp, // will need start and end timestamps, backend update
+            start_timestamp: moment.startTimestamp,
+            end_timestamp: moment.endTimestamp,
             label: moment.label,
+            color: moment.color,
         }));
 
-        // first, get session ids from backend
-        const sessionId = await getSessions();
-        console.log('Session ids:', sessionId);
-
-        if (sessionIdSentToBackend === null) {
-            console.error('Session id not sent to backend');
-            return;
+        try {
+            await saveTimeLabels(sessionIdSentToBackend, payload);
+            unsentLabels.forEach((moment) => sentLabelIdsRef.current.add(moment.id));
+            console.log('POST time labels success:', payload);
+        } catch (e) {
+            console.error('Failed to POST time labels:', e);
         }
-
-        void saveTimeLabels(sessionIdSentToBackend, payload).then(() => {
-            console.log('POST time labels:', payload);
-        });
     }, [sessionIdSentToBackend]);
 
     React.useEffect(() => {
@@ -306,6 +306,23 @@ export default function LabelNode({ id }: LabelNodeProps) {
     const handleTimelineViewClick = () => {
         setViewMode('timeline');
     };
+
+    const handleFetchLabelData = React.useCallback(async (start: string, end: string): Promise<LabelGraphPoint[]> => {
+        if (sessionIdSentToBackend === null) return [];
+        try {
+            const rows = await getEegData(sessionIdSentToBackend, start, end);
+            return rows.map((row, index) => ({
+                id: `fetched-${index}`,
+                time: row.time,
+                signal1: row.channel1,
+                signal2: row.channel2,
+                signal3: row.channel3,
+                signal4: row.channel4,
+            }));
+        } catch {
+            return [];
+        }
+    }, [sessionIdSentToBackend]);
 
     const timelineRows = React.useMemo<TimelineLabelRow[]>(() => {
         const completedRows: TimelineLabelRow[] = labeledMoments.map((moment) => ({
@@ -412,6 +429,7 @@ export default function LabelNode({ id }: LabelNodeProps) {
                 graphData={graphData}
                 sessionStartTimestamp={sessionStartTimestamp}
                 latestBackendTimestamp={latestBackendTimestamp}
+                fetchDataForLabel={handleFetchLabelData}
             />
         </div>
     );

--- a/frontend/components/nodes/label-node/label-timeline-panel.tsx
+++ b/frontend/components/nodes/label-node/label-timeline-panel.tsx
@@ -88,7 +88,9 @@ const parseTimestampMs = (timestamp: string | null): number | null => {
         }
     }
 
-    const value = Date.parse(timestamp);
+    // Truncate sub-millisecond precision (nanoseconds) so Date.parse succeeds.
+    const truncated = timestamp.replace(/(\.\d{3})\d+/, '$1');
+    const value = Date.parse(truncated);
     if (!Number.isNaN(value)) {
         return value;
     }
@@ -359,11 +361,13 @@ export default function LabelTimelinePanel({
 
     // Chart data with a numeric timeMs field so XAxis can use type="number"
     // and ReferenceArea can use reliable numeric x1/x2.
+    // Points with unparseable timestamps are filtered out to prevent domain corruption.
     const chartData = React.useMemo(() =>
-        displayedGraphData.map((p) => ({
-            ...p,
-            timeMs: parseTimestampMs(p.time) ?? 0,
-        })),
+        displayedGraphData.flatMap((p) => {
+            const timeMs = parseTimestampMs(p.time);
+            if (timeMs === null || timeMs === 0) return [];
+            return [{ ...p, timeMs }];
+        }),
     [displayedGraphData]);
 
     const handleGraphEventClick = React.useCallback(
@@ -543,6 +547,11 @@ export default function LabelTimelinePanel({
                             {!isFetchingData && selectedGraphEventId && fetchedFocusData === null && (
                                 <div className="absolute inset-0 flex items-center justify-center bg-white/80 z-10 rounded-[10px]">
                                     <span className="text-sm text-[#8A8A8A]">No recorded data for this event</span>
+                                </div>
+                            )}
+                            {!isFetchingData && !selectedGraphEventId && chartData.length === 0 && (
+                                <div className="absolute inset-0 flex items-center justify-center z-10 rounded-[10px]">
+                                    <span className="text-sm text-[#8A8A8A]">Start streaming to see live data</span>
                                 </div>
                             )}
                             <ResponsiveContainer width="100%" height="100%">

--- a/frontend/components/nodes/label-node/label-timeline-panel.tsx
+++ b/frontend/components/nodes/label-node/label-timeline-panel.tsx
@@ -357,6 +357,15 @@ export default function LabelTimelinePanel({
         return focused.map(({ timeMs: _timeMs, ...point }) => point);
     }, [fetchedFocusData, focusWindowMs, graphData, normalizedGraphData]);
 
+    // Chart data with a numeric timeMs field so XAxis can use type="number"
+    // and ReferenceArea can use reliable numeric x1/x2.
+    const chartData = React.useMemo(() =>
+        displayedGraphData.map((p) => ({
+            ...p,
+            timeMs: parseTimestampMs(p.time) ?? 0,
+        })),
+    [displayedGraphData]);
+
     const handleGraphEventClick = React.useCallback(
         (row: TimelineLabelRow) => {
             const startMs = parseTimestampMs(row.startTimestamp);
@@ -395,36 +404,22 @@ export default function LabelTimelinePanel({
         setIsFetchingData(false);
     }, []);
 
-    const referenceAreaTimes = React.useMemo(() => {
-        if (!selectedGraphEventId) return null;
+    const referenceAreaMs = React.useMemo((): { x1: number; x2: number } | null => {
+        if (!selectedGraphEventId || !selectedEventMs) return null;
 
-        // When fetched data is available, it spans exactly the event range —
-        // use first and last point times directly to avoid timestamp parsing issues.
-        if (fetchedFocusData && fetchedFocusData.length >= 2) {
-            return {
-                x1: fetchedFocusData[0].time,
-                x2: fetchedFocusData[fetchedFocusData.length - 1].time,
-            };
+        // When fetched data is available use its actual time range.
+        if (fetchedFocusData && fetchedFocusData.length >= 1) {
+            const times = fetchedFocusData
+                .map((p) => parseTimestampMs(p.time))
+                .filter((t): t is number => t !== null);
+            if (times.length >= 1) {
+                return { x1: Math.min(...times), x2: Math.max(...times) };
+            }
         }
 
-        // Fall back: find closest times in live displayed data.
-        if (!selectedEventMs || displayedGraphData.length === 0) return null;
-        const findClosestTime = (targetMs: number) => {
-            let closest = displayedGraphData[0];
-            let minDiff = Infinity;
-            for (const point of displayedGraphData) {
-                const pointMs = parseTimestampMs(point.time);
-                if (pointMs === null) continue;
-                const diff = Math.abs(pointMs - targetMs);
-                if (diff < minDiff) { minDiff = diff; closest = point; }
-            }
-            return closest.time;
-        };
-        return {
-            x1: findClosestTime(selectedEventMs.startMs),
-            x2: findClosestTime(selectedEventMs.endMs),
-        };
-    }, [selectedGraphEventId, fetchedFocusData, selectedEventMs, displayedGraphData]);
+        // Fall back to the event's own start/end ms.
+        return { x1: selectedEventMs.startMs, x2: selectedEventMs.endMs };
+    }, [selectedGraphEventId, fetchedFocusData, selectedEventMs]);
     // end of new, not sure if this works
 
     const timelineScrollRef = React.useRef<HTMLDivElement | null>(null);
@@ -551,19 +546,16 @@ export default function LabelTimelinePanel({
                                 </div>
                             )}
                             <ResponsiveContainer width="100%" height="100%">
-                                <LineChart data={displayedGraphData} margin={{ top: 8, right: 16, bottom: 24, left: 16 }}>
+                                <LineChart data={chartData} margin={{ top: 8, right: 16, bottom: 24, left: 16 }}>
                                     <CartesianGrid
                                         strokeDasharray="3 3"
                                         stroke="#E7E7E7"
                                     />
                                     <XAxis
-                                        dataKey="time"
-                                        tickFormatter={(value) =>
-                                            formatAbsoluteTime(
-                                                parseTimestampMs(String(value)) ??
-                                                    Date.now()
-                                            )
-                                        }
+                                        dataKey="timeMs"
+                                        type="number"
+                                        domain={['dataMin', 'dataMax']}
+                                        tickFormatter={(value) => formatAbsoluteTime(value)}
                                         tick={{ fontSize: 11, fill: '#7A7A7A' }}
                                         label={{ value: 'Time (HH:MM:SS)', position: 'insideBottom', offset: -14, fontSize: 10, fill: '#666' }}
                                     />
@@ -573,10 +565,10 @@ export default function LabelTimelinePanel({
                                         width={60}
                                         label={{ value: 'Frequency (Hz)', angle: -90, position: 'insideLeft', dy: 55, dx: 4, fontSize: 10, fill: '#666' }}
                                     />
-                                    {referenceAreaTimes && (
+                                    {referenceAreaMs && (
                                         <ReferenceArea
-                                            x1={referenceAreaTimes.x1}
-                                            x2={referenceAreaTimes.x2}
+                                            x1={referenceAreaMs.x1}
+                                            x2={referenceAreaMs.x2}
                                             fill="#2E7B75"
                                             fillOpacity={0.12}
                                             stroke="#2E7B75"

--- a/frontend/components/nodes/label-node/label-timeline-panel.tsx
+++ b/frontend/components/nodes/label-node/label-timeline-panel.tsx
@@ -1,0 +1,728 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import { colorClassMap, LabelColor } from './label-combo-box';
+import {
+    CartesianGrid,
+    Line,
+    LineChart,
+    ResponsiveContainer,
+    XAxis,
+    YAxis,
+} from 'recharts';
+
+export type TimelineRowSource = 'Trigger' | 'Manual' | 'Auto';
+
+export interface TimelineLabelRow {
+    id: string;
+    label: string;
+    color: LabelColor;
+    startTimestamp: string;
+    endTimestamp: string | null;
+    source: TimelineRowSource;
+    isInProgress: boolean;
+}
+
+export interface LabelGraphPoint {
+    id: string;
+    time: string;
+    signal1: number;
+    signal2: number;
+    signal3: number;
+    signal4: number;
+}
+
+export interface LabelTimelinePanelProps {
+    isExpanded: boolean;
+    rows: TimelineLabelRow[];
+    sessionStartTimestamp: string | null;
+    latestBackendTimestamp: string | null;
+    isConnected: boolean;
+    isDataStreamOn: boolean;
+    onClose: () => void;
+    onGraphViewClick?: () => void;
+    onTimelineViewClick?: () => void;
+    viewMode: 'timeline' | 'graph';
+    graphData: LabelGraphPoint[];
+}
+
+interface PackedTimelineEntry {
+    row: TimelineLabelRow;
+    startMs: number;
+    endMs: number;
+    laneIndex: number;
+}
+
+interface FocusWindowMs {
+    startMs: number;
+    endMs: number;
+}
+
+const colorBorderMap: Record<LabelColor, string> = {
+    'teal-700': 'border-[#2E7B75]',
+    'teal-500': 'border-[#6CAFA4]',
+    'teal-300': 'border-[#98CDBF]',
+    'mint-100': 'border-[#D6E6D4]',
+};
+const VISIBLE_WINDOW_MS = 30_000;
+const TICK_INTERVAL_MS = 5_000;
+const LIVE_EDGE_EPSILON_PX = 4;
+
+const parseTimestampMs = (timestamp: string | null): number | null => {
+    if (!timestamp) return null;
+
+    if (/^\d+$/.test(timestamp)) {
+        const numeric = Number(timestamp);
+        if (Number.isFinite(numeric)) {
+            return timestamp.length <= 10 ? numeric * 1000 : numeric;
+        }
+    }
+
+    const value = Date.parse(timestamp);
+    if (!Number.isNaN(value)) {
+        return value;
+    }
+
+    // Support truncated websocket timestamps like "HH:mm:ss" or "HH:mm:ss.SSS".
+    const timeOnlyMatch = timestamp.match(
+        /^(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,3}))?$/
+    );
+    if (!timeOnlyMatch) {
+        return null;
+    }
+
+    const hours = Number(timeOnlyMatch[1]);
+    const minutes = Number(timeOnlyMatch[2]);
+    const seconds = Number(timeOnlyMatch[3]);
+    const milliseconds = Number((timeOnlyMatch[4] ?? '0').padEnd(3, '0').slice(0, 3));
+
+    const baseDate = new Date();
+    baseDate.setHours(hours, minutes, seconds, milliseconds);
+    return baseDate.getTime();
+};
+
+const formatAbsoluteTime = (ms: number): string => {
+    const date = new Date(ms);
+    return `${date.getHours().toString().padStart(2, '0')}:${date
+        .getMinutes()
+        .toString()
+        .padStart(2, '0')}:${date.getSeconds().toString().padStart(2, '0')}`;
+};
+
+const formatAbsoluteTimeWithMs = (ms: number): string => {
+    const date = new Date(ms);
+    return `${date.getHours().toString().padStart(2, '0')}:${date
+        .getMinutes()
+        .toString()
+        .padStart(2, '0')}:${date.getSeconds().toString().padStart(2, '0')}.${date
+        .getMilliseconds()
+        .toString()
+        .padStart(3, '0')}`;
+};
+
+const formatDuration = (ms: number | null): string => {
+    if (ms == null || ms < 0) return '-';
+    if (ms < 1000) return '<1s';
+    if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+    const minutes = Math.floor(ms / 60_000);
+    const seconds = Math.round((ms % 60_000) / 1000);
+    return `${minutes}m ${seconds}s`;
+};
+
+export default function LabelTimelinePanel({
+    isExpanded,
+    rows,
+    sessionStartTimestamp,
+    latestBackendTimestamp,
+    onClose,
+    onGraphViewClick,
+    onTimelineViewClick,
+    viewMode,
+    isConnected,
+    isDataStreamOn,
+    graphData,
+}: LabelTimelinePanelProps) {
+    const latestMs = parseTimestampMs(latestBackendTimestamp);
+    const fallbackStartMs = parseTimestampMs(sessionStartTimestamp);
+
+    const axisStartMs = React.useMemo(() => {
+        const startCandidates = rows
+            .map((row) => parseTimestampMs(row.startTimestamp))
+            .filter((value): value is number => value !== null);
+
+        if (startCandidates.length > 0) {
+            return Math.min(...startCandidates);
+        }
+
+        if (fallbackStartMs !== null) {
+            return fallbackStartMs;
+        }
+
+        if (latestMs !== null) {
+            return latestMs - 60_000;
+        }
+
+        return Date.now() - 60_000;
+    }, [fallbackStartMs, latestMs, rows]);
+
+    const axisEndMs = React.useMemo(() => {
+        const endCandidates = rows
+            .map((row) => parseTimestampMs(row.endTimestamp ?? latestBackendTimestamp))
+            .filter((value): value is number => value !== null);
+
+        if (latestMs !== null) endCandidates.push(latestMs);
+        if (endCandidates.length === 0) {
+            return axisStartMs + 60_000;
+        }
+
+        const maxValue = Math.max(...endCandidates);
+        return Math.max(maxValue, axisStartMs + VISIBLE_WINDOW_MS);
+    }, [axisStartMs, rows, latestBackendTimestamp, latestMs]);
+
+    const elapsedDurationMs = Math.max(axisEndMs - axisStartMs, 1);
+    const virtualDurationMs = Math.max(elapsedDurationMs, VISIBLE_WINDOW_MS);
+    const virtualTrackWidthPercent = (virtualDurationMs / VISIBLE_WINDOW_MS) * 100;
+
+    const ticks = React.useMemo(() => {
+        const tickCount = Math.floor(virtualDurationMs / TICK_INTERVAL_MS) + 1;
+        return Array.from({ length: tickCount }, (_, index) => {
+            const offsetMs = index * TICK_INTERVAL_MS;
+            const absoluteMs = axisStartMs + offsetMs;
+            return {
+                ratio: offsetMs / virtualDurationMs,
+                label: formatAbsoluteTime(absoluteMs),
+            };
+        }).filter((tick) => tick.ratio >= 0 && tick.ratio <= 1.0001);
+    }, [axisStartMs, virtualDurationMs]);
+
+    const tableRows = [...rows].sort((a, b) => {
+        const bStart = parseTimestampMs(b.startTimestamp) ?? 0;
+        const aStart = parseTimestampMs(a.startTimestamp) ?? 0;
+        return bStart - aStart;
+    });
+
+    const packedEntries = React.useMemo<PackedTimelineEntry[]>(() => {
+        const normalized = rows
+            .map((row) => {
+                const startMs = parseTimestampMs(row.startTimestamp);
+                const endMs = parseTimestampMs(
+                    row.endTimestamp ?? latestBackendTimestamp
+                );
+                if (startMs === null || endMs === null) {
+                    return null;
+                }
+                return {
+                    row,
+                    startMs,
+                    endMs: Math.max(endMs, startMs + 1),
+                };
+            })
+            .filter(
+                (
+                    value
+                ): value is {
+                    row: TimelineLabelRow;
+                    startMs: number;
+                    endMs: number;
+                } => value !== null
+            )
+            .sort((a, b) => {
+                if (a.startMs !== b.startMs) {
+                    return a.startMs - b.startMs;
+                }
+                return a.endMs - b.endMs;
+            });
+
+        const laneEndTimes: number[] = [];
+        const packed: PackedTimelineEntry[] = [];
+
+        normalized.forEach((entry) => {
+            const reusableLaneIndex = laneEndTimes.findIndex(
+                (laneEndTime) => entry.startMs >= laneEndTime
+            );
+
+            if (reusableLaneIndex === -1) {
+                laneEndTimes.push(entry.endMs);
+                packed.push({
+                    ...entry,
+                    laneIndex: laneEndTimes.length - 1,
+                });
+                return;
+            }
+
+            laneEndTimes[reusableLaneIndex] = entry.endMs;
+            packed.push({
+                ...entry,
+                laneIndex: reusableLaneIndex,
+            });
+        });
+
+        return packed;
+    }, [latestBackendTimestamp, rows]);
+
+    const laneGroups = React.useMemo(() => {
+        const totalLanes =
+            packedEntries.length > 0
+                ? Math.max(...packedEntries.map((entry) => entry.laneIndex)) + 1
+                : 0;
+        const groups: PackedTimelineEntry[][] = Array.from(
+            { length: totalLanes },
+            () => []
+        );
+
+        packedEntries.forEach((entry) => {
+            groups[entry.laneIndex].push(entry);
+        });
+
+        return groups;
+    }, [packedEntries]);
+
+    const [highlightedSignal, setHighlightedSignal] = React.useState<
+        'signal1' | 'signal2' | 'signal3' | 'signal4'>('signal1');
+    const [selectedGraphEventId, setSelectedGraphEventId] = React.useState<
+        string | null
+    >(null);
+    const [focusWindowMs, setFocusWindowMs] =
+        React.useState<FocusWindowMs | null>(null);
+
+    const signalConfigs: Array<{
+        key: 'signal1' | 'signal2' | 'signal3' | 'signal4';
+        label: string;
+        color: string;
+    }> = [
+        { key: 'signal1', label: 'Signal 1', color: '#2E7B75' },
+        { key: 'signal2', label: 'Signal 2', color: '#6CAFA4' },
+        { key: 'signal3', label: 'Signal 3', color: '#98CDBF' },
+        { key: 'signal4', label: 'Signal 4', color: '#D6E6D4' },
+    ];
+
+    const toggleSignal = (
+        signalKey: 'signal1' | 'signal2' | 'signal3' | 'signal4'
+    ) => {
+        setHighlightedSignal(signalKey);
+    };
+
+    // beginning of new, not sure if this works
+    const normalizedGraphData = React.useMemo(() => {
+        return graphData
+            .map((point) => {
+                const timeMs = parseTimestampMs(point.time);
+                if (timeMs === null) {
+                    return null;
+                }
+                return { ...point, timeMs };
+            })
+            .filter(
+                (
+                    point
+                ): point is LabelGraphPoint & {
+                    timeMs: number;
+                } => point !== null
+            );
+    }, [graphData]);
+
+    const displayedGraphData = React.useMemo<LabelGraphPoint[]>(() => {
+        if (!focusWindowMs) {
+            return graphData;
+        }
+
+        const focused = normalizedGraphData.filter(
+            (point) =>
+                point.timeMs >= focusWindowMs.startMs &&
+                point.timeMs <= focusWindowMs.endMs
+        );
+
+        if (focused.length === 0) {
+            return graphData;
+        }
+
+        return focused.map(({ timeMs: _timeMs, ...point }) => point);
+    }, [focusWindowMs, graphData, normalizedGraphData]);
+
+    const handleGraphEventClick = React.useCallback(
+        (row: TimelineLabelRow) => {
+            const startMs = parseTimestampMs(row.startTimestamp);
+            const endMs = parseTimestampMs(row.endTimestamp ?? latestBackendTimestamp);
+
+            if (startMs === null || endMs === null) {
+                return;
+            }
+
+            const durationMs = Math.max(endMs - startMs, 1_000);
+            const paddingMs = Math.max(Math.floor(durationMs * 0.1), 500);
+
+            setSelectedGraphEventId(row.id);
+            setFocusWindowMs({
+                startMs: startMs - paddingMs,
+                endMs: endMs + paddingMs,
+            });
+            // TODO: get data for focused window from backend.
+        },
+        [latestBackendTimestamp]
+    );
+
+    const handleReturnToLive = React.useCallback(() => {
+        setSelectedGraphEventId(null);
+        setFocusWindowMs(null);
+    }, []);
+    // end of new, not sure if this works
+
+    const timelineScrollRef = React.useRef<HTMLDivElement | null>(null);
+    const isAtLiveEdgeRef = React.useRef(true);
+
+    const handleTimelineScroll = React.useCallback(() => {
+        const node = timelineScrollRef.current;
+        if (!node) {
+            return;
+        }
+
+        isAtLiveEdgeRef.current =
+            node.scrollLeft + node.clientWidth >=
+            node.scrollWidth - LIVE_EDGE_EPSILON_PX;
+    }, []);
+
+    React.useEffect(() => {
+        if (viewMode !== 'timeline') {
+            return;
+        }
+
+        const node = timelineScrollRef.current;
+        if (!node || !isAtLiveEdgeRef.current) {
+            return;
+        }
+
+        node.scrollLeft = Math.max(node.scrollWidth - node.clientWidth, 0);
+    }, [axisEndMs, laneGroups.length, virtualTrackWidthPercent, viewMode]);
+
+    if (!isExpanded) {
+        return null;
+    }
+
+    return (
+        <div className="mx-4 mb-4 rounded-[24px] border border-[#D3D3D3] bg-[#F8F9F8] p-4">
+            <div className="mb-4 flex items-center justify-between">
+                <div className="flex items-center gap-2">
+
+                    {/* Status dot */}
+                    <div
+                        className={cn(
+                            'absolute left-16 w-3 h-3 rounded-full',
+                            isConnected && isDataStreamOn
+                                ? 'bg-[#509693]'
+                                : 'bg-[#D3D3D3]'
+                        )}
+                    />
+                    <h3 className="absolute left-24 font-geist text-[25px] font-[550] leading-tight text-black">
+                        Timeline
+                    </h3>
+                </div>
+
+                <div className="flex items-center gap-2">
+                    {viewMode === 'graph' && selectedGraphEventId && (
+                        <button
+                            className="nodrag nopan rounded-md border border-[#D3D3D3] bg-white px-3 py-1 text-sm text-[#7A7A7A] hover:bg-[#F2F2F2] transition-colors"
+                            onClick={handleReturnToLive}
+                        >
+                            Return to Live
+                        </button>
+                    )}
+                    <button
+                        className="nodrag nopan rounded-md border border-[#D3D3D3] bg-white px-3 py-1 text-sm text-[#7A7A7A] hover:bg-[#F2F2F2] transition-colors"
+                        onClick={
+                            viewMode === 'graph'
+                                ? onTimelineViewClick
+                                : onGraphViewClick
+                        }
+                    >
+                        {viewMode === 'graph' ? 'Timeline View' : 'Graph View'}
+                    </button>
+                    <button
+                        className="nodrag nopan text-[#BFBFBF] hover:text-[#8F8F8F] text-xl leading-none transition-colors"
+                        onClick={onClose}
+                        aria-label="Close timeline panel"
+                    >
+                        ×
+                    </button>
+                </div>
+            </div>
+
+            {viewMode === 'graph' ? (
+                <div className="mb-5 rounded-[16px] border border-[#D3D3D3] bg-white p-3">
+                    <div className="grid grid-cols-[1fr_140px] gap-4">
+                        <div className="h-[320px] rounded-[12px] border border-[#E2E2E2] bg-white p-2">
+                            <ResponsiveContainer width="100%" height="100%">
+                                <LineChart data={displayedGraphData}>
+                                    <CartesianGrid
+                                        strokeDasharray="3 3"
+                                        stroke="#E7E7E7"
+                                    />
+                                    <XAxis
+                                        dataKey="time"
+                                        tickFormatter={(value) =>
+                                            formatAbsoluteTime(
+                                                parseTimestampMs(String(value)) ??
+                                                    Date.now()
+                                            )
+                                        }
+                                        tick={{ fontSize: 11, fill: '#7A7A7A' }}
+                                    />
+                                    <YAxis
+                                        tick={{ fontSize: 11, fill: '#7A7A7A' }}
+                                    />
+                                    {[...signalConfigs.filter((s) => s.key !== highlightedSignal),
+                                      ...signalConfigs.filter((s) => s.key === highlightedSignal),
+                                    ].map((signal) => (
+                                        <Line
+                                            key={signal.key}
+                                            dataKey={signal.key}
+                                            type="monotone"
+                                            isAnimationActive={false}
+                                            dot={false}
+                                            stroke={
+                                                highlightedSignal === signal.key
+                                                    ? '#FF0000'
+                                                    : '#D3D3D3' // red
+                                            }
+                                            strokeWidth={
+                                                highlightedSignal === signal.key
+                                                    ? 2
+                                                    : 1.2
+                                            }
+                                        />
+                                    ))}
+                                </LineChart>
+                            </ResponsiveContainer>
+                        </div>
+
+                        <div className="space-y-4">
+                            <div>
+                                <h4 className="mb-2 text-sm font-semibold text-black">
+                                    Highlight
+                                </h4>
+                                <div className="space-y-2">
+                                    {signalConfigs.map((signal) => (
+                                        <button
+                                            key={signal.key}
+                                            className="nodrag nopan flex items-center gap-2 text-sm text-black"
+                                            onClick={() =>
+                                                toggleSignal(signal.key)
+                                            }
+                                        >
+                                            <span
+                                                className={cn(
+                                                    'h-3 w-3 rounded-sm border',
+                                                    highlightedSignal === signal.key
+                                                        ? 'border-[#2E7B75] bg-[#2E7B75]'
+                                                        : 'border-[#BFBFBF] bg-white'
+                                                )}
+                                            />
+                                            {signal.label}
+                                        </button>
+                                    ))}
+                                </div>
+                            </div>
+
+                            <div>
+                                <h4 className="mb-2 text-sm font-semibold text-black">
+                                    Events
+                                </h4>
+                                <div className="max-h-[180px] space-y-2 overflow-y-auto pr-1">
+                                    {tableRows.length === 0 ? (
+                                        <div className="text-sm text-[#8A8A8A]">
+                                            No events yet.
+                                        </div>
+                                    ) : (
+                                        tableRows.map((row) => {
+                                            const startMs = parseTimestampMs(
+                                                row.startTimestamp
+                                            );
+                                            const isSelected =
+                                                row.id === selectedGraphEventId;
+
+                                            return (
+                                                <button
+                                                    key={row.id}
+                                                    className={cn(
+                                                        'nodrag nopan w-full rounded-md border px-2 py-1.5 text-left text-sm transition-colors',
+                                                        isSelected
+                                                            ? 'border-[#2E7B75] bg-[#E8F2F1] text-[#163B39]'
+                                                            : 'border-[#BFD9D7] text-[#204C49] hover:bg-[#EEF3F2]'
+                                                    )}
+                                                    onClick={() => handleGraphEventClick(row)}
+                                                >
+                                                    <div className="flex items-center justify-between gap-2">
+                                                        <span className="truncate font-medium">
+                                                            {row.label}
+                                                        </span>
+                                                        {row.isInProgress && (
+                                                            <span className="text-xs text-[#5E8B87]">
+                                                                Live
+                                                            </span>
+                                                        )}
+                                                    </div>
+                                                    <div className="mt-0.5 text-xs text-[#5A5A5A]">
+                                                        {startMs !== null
+                                                            ? formatAbsoluteTimeWithMs(
+                                                                  startMs
+                                                              )
+                                                            : '--:--'}
+                                                    </div>
+                                                </button>
+                                            );
+                                        })
+                                    )}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            ) : (
+                <div className="mb-5 rounded-[16px] border border-[#D3D3D3] bg-white p-3">
+                    <div
+                        ref={timelineScrollRef}
+                        onScroll={handleTimelineScroll}
+                        className="w-full overflow-x-auto rounded-md border border-[#E2E2E2] pb-2"
+                    >
+                        <div
+                            className="min-w-full"
+                            style={{ width: `${virtualTrackWidthPercent}%` }}
+                        >
+                            <div className="mb-3 relative h-6 border-b border-[#D3D3D3]">
+                                {ticks.map((tick) => (
+                                    <div
+                                        key={`${tick.ratio}-${tick.label}`}
+                                        className="absolute top-0 -translate-x-1/2 text-xs text-[#7A7A7A]"
+                                        style={{ left: `${tick.ratio * 100}%` }}
+                                    >
+                                        {tick.label}
+                                    </div>
+                                ))}
+                            </div>
+
+                            <div className="space-y-2">
+                                {laneGroups.length === 0 && (
+                                    <div className="py-3 text-sm text-[#8A8A8A]">
+                                        No labels yet. Start/stop Trigger to add moments.
+                                    </div>
+                                )}
+
+                                {laneGroups.map((laneEntries, laneIndex) => (
+                                    <div
+                                        key={`timeline-lane-${laneIndex}`}
+                                        className="relative h-8 w-full rounded-md bg-[#EEF3F2]"
+                                    >
+                                        {laneEntries.map((entry) => {
+                                            const startOffset = Math.max(
+                                                entry.startMs - axisStartMs,
+                                                0
+                                            );
+                                            const endOffset = Math.max(
+                                                entry.endMs - axisStartMs,
+                                                startOffset + 1
+                                            );
+                                            const leftPercent =
+                                                (startOffset / virtualDurationMs) * 100;
+                                            const widthPercent = Math.max(
+                                                ((endOffset - startOffset) /
+                                                    virtualDurationMs) *
+                                                    100,
+                                                2
+                                            );
+
+                                            return (
+                                                <div
+                                                    key={entry.row.id}
+                                                    className={cn(
+                                                        'absolute top-0 h-full rounded-md border flex items-center px-3 text-sm text-[#204C49]',
+                                                        colorClassMap[entry.row.color],
+                                                        colorBorderMap[entry.row.color],
+                                                        entry.row.isInProgress ? 'animate-pulse' : ''
+                                                    )}
+                                                    style={{
+                                                        left: `${leftPercent}%`,
+                                                        width: `${Math.min(
+                                                            widthPercent,
+                                                            100 - leftPercent
+                                                        )}%`,
+                                                    }}
+                                                >
+                                                    {entry.row.label}
+                                                    {entry.row.isInProgress
+                                                        ? ' (recording)'
+                                                        : ''}
+                                                </div>
+                                            );
+                                        })}
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            {viewMode === 'timeline' && (
+                <div className="rounded-[16px] border border-[#D3D3D3] bg-white p-3">
+                <h3 className="mb-3 font-geist text-[25px] font-[550] leading-tight text-black">
+                    Event Log
+                </h3>
+
+                <div className="max-h-[210px] overflow-y-auto rounded-md border border-[#E2E2E2]">
+                    <table className="w-full text-left text-sm">
+                        <thead className="sticky top-0 bg-[#F0F0F0] text-black">
+                            <tr>
+                                <th className="px-3 py-2 font-medium">Time</th>
+                                <th className="px-3 py-2 font-medium">Label</th>
+                                <th className="px-3 py-2 font-medium">Duration</th>
+                                <th className="px-3 py-2 font-medium">Source</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {tableRows.length === 0 && (
+                                <tr>
+                                    <td
+                                        colSpan={4}
+                                        className="px-3 py-3 text-[#8A8A8A]"
+                                    >
+                                        No events logged yet.
+                                    </td>
+                                </tr>
+                            )}
+
+                            {tableRows.map((row) => {
+                                const startMs = parseTimestampMs(row.startTimestamp);
+                                const endMs = parseTimestampMs(
+                                    row.endTimestamp ?? latestBackendTimestamp
+                                );
+                                const durationMs =
+                                    startMs !== null && endMs !== null
+                                        ? endMs - startMs
+                                        : null;
+
+                                return (
+                                    <tr key={row.id} className="border-t border-[#EFEFEF]">
+                                        <td className="px-3 py-2 text-[#5A5A5A]">
+                                            {startMs !== null
+                                                ? formatAbsoluteTimeWithMs(startMs)
+                                                : '--:--'}
+                                        </td>
+                                        <td className="px-3 py-2 text-black">
+                                            {row.label}
+                                            {row.isInProgress ? ' (recording)' : ''}
+                                        </td>
+                                        <td className="px-3 py-2 text-[#5A5A5A]">
+                                            {formatDuration(durationMs)}
+                                        </td>
+                                        <td className="px-3 py-2 text-[#5A5A5A]">
+                                            {row.source}
+                                        </td>
+                                    </tr>
+                                );
+                            })}
+                        </tbody>
+                    </table>
+                </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/frontend/components/nodes/label-node/label-timeline-panel.tsx
+++ b/frontend/components/nodes/label-node/label-timeline-panel.tsx
@@ -60,18 +60,11 @@ interface FocusWindowMs {
     endMs: number;
 }
 
-const colorBorderMap: Record<LabelColor, string> = {
-    'teal-700': 'border-[#2E7B75]',
-    'teal-500': 'border-[#6CAFA4]',
-    'teal-300': 'border-[#98CDBF]',
-    'mint-100': 'border-[#D6E6D4]',
-};
-
-const colorTextMap: Record<LabelColor, string> = {
-    'teal-700': 'text-[#2E7B75]',
-    'teal-500': 'text-[#6CAFA4]',
-    'teal-300': 'text-[#98CDBF]',
-    'mint-100': 'text-[#D6E6D4]',
+const colorFillTextMap: Record<LabelColor, string> = {
+    'teal-700': 'text-white',
+    'teal-500': 'text-white',
+    'teal-300': 'text-white',
+    'mint-100': 'text-[#2E7B75]',
 };
 
 const colorHexMap: Record<LabelColor, string> = {
@@ -302,7 +295,9 @@ export default function LabelTimelinePanel({
     >(null);
     const [focusWindowMs, setFocusWindowMs] =
         React.useState<FocusWindowMs | null>(null);
+    const [selectedEventMs, setSelectedEventMs] = React.useState<FocusWindowMs | null>(null);
     const [fetchedFocusData, setFetchedFocusData] = React.useState<LabelGraphPoint[] | null>(null);
+    const [isFetchingData, setIsFetchingData] = React.useState(false);
 
     const signalConfigs: Array<{
         key: 'signal1' | 'signal2' | 'signal3' | 'signal4';
@@ -375,15 +370,18 @@ export default function LabelTimelinePanel({
             const paddingMs = Math.max(Math.floor(durationMs * 0.1), 500);
 
             setSelectedGraphEventId(row.id);
+            setSelectedEventMs({ startMs, endMs });
             setFocusWindowMs({
                 startMs: startMs - paddingMs,
                 endMs: endMs + paddingMs,
             });
 
             if (fetchDataForLabel && row.endTimestamp) {
+                setIsFetchingData(true);
                 fetchDataForLabel(row.startTimestamp, row.endTimestamp)
                     .then((data) => setFetchedFocusData(data.length > 0 ? data : null))
-                    .catch(() => setFetchedFocusData(null));
+                    .catch(() => setFetchedFocusData(null))
+                    .finally(() => setIsFetchingData(false));
             }
         },
         [latestBackendTimestamp, fetchDataForLabel]
@@ -392,8 +390,41 @@ export default function LabelTimelinePanel({
     const handleReturnToLive = React.useCallback(() => {
         setSelectedGraphEventId(null);
         setFocusWindowMs(null);
+        setSelectedEventMs(null);
         setFetchedFocusData(null);
+        setIsFetchingData(false);
     }, []);
+
+    const referenceAreaTimes = React.useMemo(() => {
+        if (!selectedGraphEventId) return null;
+
+        // When fetched data is available, it spans exactly the event range —
+        // use first and last point times directly to avoid timestamp parsing issues.
+        if (fetchedFocusData && fetchedFocusData.length >= 2) {
+            return {
+                x1: fetchedFocusData[0].time,
+                x2: fetchedFocusData[fetchedFocusData.length - 1].time,
+            };
+        }
+
+        // Fall back: find closest times in live displayed data.
+        if (!selectedEventMs || displayedGraphData.length === 0) return null;
+        const findClosestTime = (targetMs: number) => {
+            let closest = displayedGraphData[0];
+            let minDiff = Infinity;
+            for (const point of displayedGraphData) {
+                const pointMs = parseTimestampMs(point.time);
+                if (pointMs === null) continue;
+                const diff = Math.abs(pointMs - targetMs);
+                if (diff < minDiff) { minDiff = diff; closest = point; }
+            }
+            return closest.time;
+        };
+        return {
+            x1: findClosestTime(selectedEventMs.startMs),
+            x2: findClosestTime(selectedEventMs.endMs),
+        };
+    }, [selectedGraphEventId, fetchedFocusData, selectedEventMs, displayedGraphData]);
     // end of new, not sure if this works
 
     const timelineScrollRef = React.useRef<HTMLDivElement | null>(null);
@@ -502,15 +533,25 @@ export default function LabelTimelinePanel({
 
             <div
                 className="mx-4 mb-4 flex flex-col gap-3 overflow-y-auto max-h-[520px]"
-                onWheel={(e) => e.stopPropagation()}
+                onWheel={(e) => { e.stopPropagation(); e.nativeEvent.stopImmediatePropagation(); }}
             >
 
             {viewMode === 'graph' ? (
                 <div className="rounded-[16px] border border-[#D3D3D3] bg-white p-3">
                     <div className="grid grid-cols-[1fr_140px] gap-4">
-                        <div className="h-[320px] rounded-[12px] border border-[#E2E2E2] bg-white p-2">
+                        <div className="h-[320px] rounded-[12px] border border-[#E2E2E2] bg-white p-2 relative">
+                            {isFetchingData && (
+                                <div className="absolute inset-0 flex items-center justify-center bg-white/80 z-10 rounded-[10px]">
+                                    <span className="text-sm text-[#6CAFA4] animate-pulse">Loading event data…</span>
+                                </div>
+                            )}
+                            {!isFetchingData && selectedGraphEventId && fetchedFocusData === null && (
+                                <div className="absolute inset-0 flex items-center justify-center bg-white/80 z-10 rounded-[10px]">
+                                    <span className="text-sm text-[#8A8A8A]">No recorded data for this event</span>
+                                </div>
+                            )}
                             <ResponsiveContainer width="100%" height="100%">
-                                <LineChart data={displayedGraphData}>
+                                <LineChart data={displayedGraphData} margin={{ top: 8, right: 16, bottom: 24, left: 16 }}>
                                     <CartesianGrid
                                         strokeDasharray="3 3"
                                         stroke="#E7E7E7"
@@ -524,10 +565,24 @@ export default function LabelTimelinePanel({
                                             )
                                         }
                                         tick={{ fontSize: 11, fill: '#7A7A7A' }}
+                                        label={{ value: 'Time (HH:MM:SS)', position: 'insideBottom', offset: -14, fontSize: 10, fill: '#666' }}
                                     />
                                     <YAxis
                                         tick={{ fontSize: 11, fill: '#7A7A7A' }}
+                                        tickFormatter={(v) => Number(v).toFixed(1)}
+                                        width={60}
+                                        label={{ value: 'Frequency (Hz)', angle: -90, position: 'insideLeft', dy: 55, dx: 4, fontSize: 10, fill: '#666' }}
                                     />
+                                    {referenceAreaTimes && (
+                                        <ReferenceArea
+                                            x1={referenceAreaTimes.x1}
+                                            x2={referenceAreaTimes.x2}
+                                            fill="#2E7B75"
+                                            fillOpacity={0.12}
+                                            stroke="#2E7B75"
+                                            strokeOpacity={0.3}
+                                        />
+                                    )}
                                     {[...signalConfigs.filter((s) => s.key !== highlightedSignal),
                                       ...signalConfigs.filter((s) => s.key === highlightedSignal),
                                     ].map((signal) => (
@@ -627,7 +682,7 @@ export default function LabelTimelinePanel({
                     <div
                         ref={timelineScrollRef}
                         onScroll={handleTimelineScroll}
-                        onWheel={(e) => e.stopPropagation()}
+                        onWheel={(e) => { e.stopPropagation(); e.nativeEvent.stopImmediatePropagation(); }}
                         className="w-full overflow-x-auto rounded-md border border-[#E2E2E2] pb-2"
                     >
                         <div
@@ -711,9 +766,9 @@ export default function LabelTimelinePanel({
                                                 <div
                                                     key={entry.row.id}
                                                     className={cn(
-                                                        'absolute top-0 h-full rounded-md border-2 bg-white flex items-center px-3 text-sm font-medium',
-                                                        colorBorderMap[entry.row.color],
-                                                        colorTextMap[entry.row.color],
+                                                        'absolute top-0 h-full rounded-md flex items-center px-3 text-sm font-medium',
+                                                        colorClassMap[entry.row.color],
+                                                        colorFillTextMap[entry.row.color],
                                                         entry.row.isInProgress ? 'animate-pulse' : ''
                                                     )}
                                                     style={{

--- a/frontend/components/nodes/label-node/label-timeline-panel.tsx
+++ b/frontend/components/nodes/label-node/label-timeline-panel.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react';
+import { ArrowLeft, BarChart2, LayoutList, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { colorClassMap, LabelColor } from './label-combo-box';
+import { LabelColor, colorClassMap } from './label-combo-box';
 import {
     CartesianGrid,
     Line,
     LineChart,
+    ReferenceArea,
     ResponsiveContainer,
     XAxis,
     YAxis,
@@ -43,6 +45,7 @@ export interface LabelTimelinePanelProps {
     onTimelineViewClick?: () => void;
     viewMode: 'timeline' | 'graph';
     graphData: LabelGraphPoint[];
+    fetchDataForLabel?: (start: string, end: string) => Promise<LabelGraphPoint[]>;
 }
 
 interface PackedTimelineEntry {
@@ -63,6 +66,21 @@ const colorBorderMap: Record<LabelColor, string> = {
     'teal-300': 'border-[#98CDBF]',
     'mint-100': 'border-[#D6E6D4]',
 };
+
+const colorTextMap: Record<LabelColor, string> = {
+    'teal-700': 'text-[#2E7B75]',
+    'teal-500': 'text-[#6CAFA4]',
+    'teal-300': 'text-[#98CDBF]',
+    'mint-100': 'text-[#D6E6D4]',
+};
+
+const colorHexMap: Record<LabelColor, string> = {
+    'teal-700': '#2E7B75',
+    'teal-500': '#6CAFA4',
+    'teal-300': '#98CDBF',
+    'mint-100': '#D6E6D4',
+};
+
 const VISIBLE_WINDOW_MS = 30_000;
 const TICK_INTERVAL_MS = 5_000;
 const LIVE_EDGE_EPSILON_PX = 4;
@@ -140,6 +158,7 @@ export default function LabelTimelinePanel({
     isConnected,
     isDataStreamOn,
     graphData,
+    fetchDataForLabel,
 }: LabelTimelinePanelProps) {
     const latestMs = parseTimestampMs(latestBackendTimestamp);
     const fallbackStartMs = parseTimestampMs(sessionStartTimestamp);
@@ -283,16 +302,17 @@ export default function LabelTimelinePanel({
     >(null);
     const [focusWindowMs, setFocusWindowMs] =
         React.useState<FocusWindowMs | null>(null);
+    const [fetchedFocusData, setFetchedFocusData] = React.useState<LabelGraphPoint[] | null>(null);
 
     const signalConfigs: Array<{
         key: 'signal1' | 'signal2' | 'signal3' | 'signal4';
         label: string;
         color: string;
     }> = [
-        { key: 'signal1', label: 'Signal 1', color: '#2E7B75' },
-        { key: 'signal2', label: 'Signal 2', color: '#6CAFA4' },
-        { key: 'signal3', label: 'Signal 3', color: '#98CDBF' },
-        { key: 'signal4', label: 'Signal 4', color: '#D6E6D4' },
+        { key: 'signal1', label: 'Channel 1', color: '#0000ff' },
+        { key: 'signal2', label: 'Channel 2', color: '#00ff00' },
+        { key: 'signal3', label: 'Channel 3',  color: '#FF00D0' },
+        { key: 'signal4', label: 'Channel 4',  color: '#FF0000' },
     ];
 
     const toggleSignal = (
@@ -321,6 +341,10 @@ export default function LabelTimelinePanel({
     }, [graphData]);
 
     const displayedGraphData = React.useMemo<LabelGraphPoint[]>(() => {
+        if (fetchedFocusData) {
+            return fetchedFocusData;
+        }
+
         if (!focusWindowMs) {
             return graphData;
         }
@@ -336,7 +360,7 @@ export default function LabelTimelinePanel({
         }
 
         return focused.map(({ timeMs: _timeMs, ...point }) => point);
-    }, [focusWindowMs, graphData, normalizedGraphData]);
+    }, [fetchedFocusData, focusWindowMs, graphData, normalizedGraphData]);
 
     const handleGraphEventClick = React.useCallback(
         (row: TimelineLabelRow) => {
@@ -355,14 +379,20 @@ export default function LabelTimelinePanel({
                 startMs: startMs - paddingMs,
                 endMs: endMs + paddingMs,
             });
-            // TODO: get data for focused window from backend.
+
+            if (fetchDataForLabel && row.endTimestamp) {
+                fetchDataForLabel(row.startTimestamp, row.endTimestamp)
+                    .then((data) => setFetchedFocusData(data.length > 0 ? data : null))
+                    .catch(() => setFetchedFocusData(null));
+            }
         },
-        [latestBackendTimestamp]
+        [latestBackendTimestamp, fetchDataForLabel]
     );
 
     const handleReturnToLive = React.useCallback(() => {
         setSelectedGraphEventId(null);
         setFocusWindowMs(null);
+        setFetchedFocusData(null);
     }, []);
     // end of new, not sure if this works
 
@@ -398,10 +428,19 @@ export default function LabelTimelinePanel({
     }
 
     return (
-        <div className="mx-4 mb-4 rounded-[24px] border border-[#D3D3D3] bg-[#F8F9F8] p-4">
-            <div className="mb-4 flex items-center justify-between">
-                <div className="flex items-center gap-2">
-
+        <div className="rounded-b-[28px] overflow-hidden">
+            {/* Header row — mirrors the collapsed node header */}
+            <div className="w-full h-[70px] px-4 flex items-center justify-between relative">
+                <div className="flex items-center">
+                    {/* Left circle */}
+                    <span
+                        className={cn(
+                            'absolute left-6 w-6 h-6 rounded-full flex items-center justify-center border-[3px]',
+                            isConnected ? 'border-black' : 'border-[#D3D3D3]'
+                        )}
+                    >
+                        {isConnected && <span className="w-3 h-3 rounded-full bg-white" />}
+                    </span>
                     {/* Status dot */}
                     <div
                         className={cn(
@@ -411,42 +450,63 @@ export default function LabelTimelinePanel({
                                 : 'bg-[#D3D3D3]'
                         )}
                     />
-                    <h3 className="absolute left-24 font-geist text-[25px] font-[550] leading-tight text-black">
-                        Timeline
+                    <h3 className="absolute left-24 font-geist text-[25px] font-[550] leading-tight text-black tracking-wider">
+                        {viewMode === 'graph' ? 'Graph View' : 'Timeline'}
                     </h3>
                 </div>
 
-                <div className="flex items-center gap-2">
+                <div className="flex items-center gap-2 pr-10">
                     {viewMode === 'graph' && selectedGraphEventId && (
                         <button
                             className="nodrag nopan rounded-md border border-[#D3D3D3] bg-white px-3 py-1 text-sm text-[#7A7A7A] hover:bg-[#F2F2F2] transition-colors"
                             onClick={handleReturnToLive}
                         >
-                            Return to Live
+                            <ArrowLeft size={14} className="inline mr-2" />Live
+                        </button>
+                    )}
+                    {viewMode === 'timeline' && (
+                        <button
+                            className="nodrag nopan rounded-md border border-[#D3D3D3] bg-white px-3 py-1 text-sm text-[#7A7A7A] hover:bg-[#F2F2F2] transition-colors flex items-center gap-2"
+                            onClick={onGraphViewClick}
+                        >
+                            <BarChart2 size={14} />
+                            Graph View
+                        </button>
+                    )}
+                    {viewMode === 'graph' && (
+                        <button
+                            className="nodrag nopan rounded-md border border-[#D3D3D3] bg-white px-3 py-1 text-sm text-[#7A7A7A] hover:bg-[#F2F2F2] transition-colors"
+                            onClick={onTimelineViewClick}
+                        >
+                            <LayoutList size={14} className="inline mr-2" />Timeline View
                         </button>
                     )}
                     <button
-                        className="nodrag nopan rounded-md border border-[#D3D3D3] bg-white px-3 py-1 text-sm text-[#7A7A7A] hover:bg-[#F2F2F2] transition-colors"
-                        onClick={
-                            viewMode === 'graph'
-                                ? onTimelineViewClick
-                                : onGraphViewClick
-                        }
-                    >
-                        {viewMode === 'graph' ? 'Timeline View' : 'Graph View'}
-                    </button>
-                    <button
-                        className="nodrag nopan text-[#BFBFBF] hover:text-[#8F8F8F] text-xl leading-none transition-colors"
+                        className="nodrag nopan text-[#BFBFBF] hover:text-[#8F8F8F] transition-colors"
                         onClick={onClose}
                         aria-label="Close timeline panel"
                     >
-                        ×
+                        <X size={18} />
                     </button>
+                    {/* Right circle */}
+                    <span
+                        className={cn(
+                            'absolute right-6 w-6 h-6 rounded-full flex items-center justify-center border-[3px]',
+                            isConnected ? 'border-black' : 'border-[#D3D3D3]'
+                        )}
+                    >
+                        {isConnected && <span className="w-3 h-3 rounded-full bg-white" />}
+                    </span>
                 </div>
             </div>
 
+            <div
+                className="mx-4 mb-4 flex flex-col gap-3 overflow-y-auto max-h-[520px]"
+                onWheel={(e) => e.stopPropagation()}
+            >
+
             {viewMode === 'graph' ? (
-                <div className="mb-5 rounded-[16px] border border-[#D3D3D3] bg-white p-3">
+                <div className="rounded-[16px] border border-[#D3D3D3] bg-white p-3">
                     <div className="grid grid-cols-[1fr_140px] gap-4">
                         <div className="h-[320px] rounded-[12px] border border-[#E2E2E2] bg-white p-2">
                             <ResponsiveContainer width="100%" height="100%">
@@ -479,13 +539,13 @@ export default function LabelTimelinePanel({
                                             dot={false}
                                             stroke={
                                                 highlightedSignal === signal.key
-                                                    ? '#FF0000'
-                                                    : '#D3D3D3' // red
+                                                    ? signal.color
+                                                    : '#C0C0C0'
                                             }
                                             strokeWidth={
                                                 highlightedSignal === signal.key
                                                     ? 2
-                                                    : 1.2
+                                                    : 1
                                             }
                                         />
                                     ))}
@@ -503,18 +563,21 @@ export default function LabelTimelinePanel({
                                         <button
                                             key={signal.key}
                                             className="nodrag nopan flex items-center gap-2 text-sm text-black"
-                                            onClick={() =>
-                                                toggleSignal(signal.key)
-                                            }
+                                            onClick={() => toggleSignal(signal.key)}
                                         >
                                             <span
-                                                className={cn(
-                                                    'h-3 w-3 rounded-sm border',
-                                                    highlightedSignal === signal.key
-                                                        ? 'border-[#2E7B75] bg-[#2E7B75]'
-                                                        : 'border-[#BFBFBF] bg-white'
+                                                className="h-3.5 w-3.5 rounded-sm flex items-center justify-center flex-shrink-0"
+                                                style={{
+                                                    backgroundColor: highlightedSignal === signal.key ? signal.color : 'transparent',
+                                                    border: highlightedSignal === signal.key ? 'none' : '1.5px solid #BFBFBF',
+                                                }}
+                                            >
+                                                {highlightedSignal === signal.key && (
+                                                    <svg width="8" height="7" viewBox="0 0 8 7" fill="none">
+                                                        <path d="M1 3L3 5.5L7 1" stroke="white" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+                                                    </svg>
                                                 )}
-                                            />
+                                            </span>
                                             {signal.label}
                                         </button>
                                     ))}
@@ -523,18 +586,15 @@ export default function LabelTimelinePanel({
 
                             <div>
                                 <h4 className="mb-2 text-sm font-semibold text-black">
-                                    Events
+                                    Event
                                 </h4>
-                                <div className="max-h-[180px] space-y-2 overflow-y-auto pr-1">
+                                <div className="max-h-[180px] space-y-1.5 overflow-y-auto pr-1">
                                     {tableRows.length === 0 ? (
                                         <div className="text-sm text-[#8A8A8A]">
                                             No events yet.
                                         </div>
                                     ) : (
                                         tableRows.map((row) => {
-                                            const startMs = parseTimestampMs(
-                                                row.startTimestamp
-                                            );
                                             const isSelected =
                                                 row.id === selectedGraphEventId;
 
@@ -542,30 +602,17 @@ export default function LabelTimelinePanel({
                                                 <button
                                                     key={row.id}
                                                     className={cn(
-                                                        'nodrag nopan w-full rounded-md border px-2 py-1.5 text-left text-sm transition-colors',
+                                                        'nodrag nopan w-full rounded-md border px-3 py-1.5 text-center text-sm transition-colors',
                                                         isSelected
                                                             ? 'border-[#2E7B75] bg-[#E8F2F1] text-[#163B39]'
-                                                            : 'border-[#BFD9D7] text-[#204C49] hover:bg-[#EEF3F2]'
+                                                            : 'border-[#D3D3D3] text-black hover:bg-[#F5F5F5]'
                                                     )}
                                                     onClick={() => handleGraphEventClick(row)}
                                                 >
-                                                    <div className="flex items-center justify-between gap-2">
-                                                        <span className="truncate font-medium">
-                                                            {row.label}
-                                                        </span>
-                                                        {row.isInProgress && (
-                                                            <span className="text-xs text-[#5E8B87]">
-                                                                Live
-                                                            </span>
-                                                        )}
-                                                    </div>
-                                                    <div className="mt-0.5 text-xs text-[#5A5A5A]">
-                                                        {startMs !== null
-                                                            ? formatAbsoluteTimeWithMs(
-                                                                  startMs
-                                                              )
-                                                            : '--:--'}
-                                                    </div>
+                                                    <span className="truncate">
+                                                        {row.label}
+                                                        {row.isInProgress ? ' •' : ''}
+                                                    </span>
                                                 </button>
                                             );
                                         })
@@ -576,17 +623,49 @@ export default function LabelTimelinePanel({
                     </div>
                 </div>
             ) : (
-                <div className="mb-5 rounded-[16px] border border-[#D3D3D3] bg-white p-3">
+                <div className="rounded-[16px] border border-[#D3D3D3] bg-white p-3">
                     <div
                         ref={timelineScrollRef}
                         onScroll={handleTimelineScroll}
+                        onWheel={(e) => e.stopPropagation()}
                         className="w-full overflow-x-auto rounded-md border border-[#E2E2E2] pb-2"
                     >
                         <div
-                            className="min-w-full"
+                            className="min-w-full relative"
                             style={{ width: `${virtualTrackWidthPercent}%` }}
                         >
-                            <div className="mb-3 relative h-6 border-b border-[#D3D3D3]">
+                            {/* Dotted vertical start/end lines for each label */}
+                            {packedEntries.map((entry) => {
+                                const startOffset = Math.max(entry.startMs - axisStartMs, 0);
+                                const endOffset = Math.max(entry.endMs - axisStartMs, startOffset + 1);
+                                const startPercent = (startOffset / virtualDurationMs) * 100;
+                                const endPercent = (endOffset / virtualDurationMs) * 100;
+                                const color = colorHexMap[entry.row.color];
+                                return (
+                                    <React.Fragment key={`lines-${entry.row.id}`}>
+                                        <div
+                                            className="absolute top-0 bottom-0 pointer-events-none"
+                                            style={{
+                                                left: `${startPercent}%`,
+                                                borderLeft: `1.5px dashed ${color}`,
+                                                zIndex: 1,
+                                            }}
+                                        />
+                                        {!entry.row.isInProgress && (
+                                            <div
+                                                className="absolute top-0 bottom-0 pointer-events-none"
+                                                style={{
+                                                    left: `${endPercent}%`,
+                                                    borderLeft: `1.5px dashed ${color}`,
+                                                    zIndex: 1,
+                                                }}
+                                            />
+                                        )}
+                                    </React.Fragment>
+                                );
+                            })}
+
+                            <div className="mb-3 relative h-6 border-b border-[#D3D3D3] z-10 bg-white">
                                 {ticks.map((tick) => (
                                     <div
                                         key={`${tick.ratio}-${tick.label}`}
@@ -608,7 +687,7 @@ export default function LabelTimelinePanel({
                                 {laneGroups.map((laneEntries, laneIndex) => (
                                     <div
                                         key={`timeline-lane-${laneIndex}`}
-                                        className="relative h-8 w-full rounded-md bg-[#EEF3F2]"
+                                        className="relative h-8 w-full"
                                     >
                                         {laneEntries.map((entry) => {
                                             const startOffset = Math.max(
@@ -632,9 +711,9 @@ export default function LabelTimelinePanel({
                                                 <div
                                                     key={entry.row.id}
                                                     className={cn(
-                                                        'absolute top-0 h-full rounded-md border flex items-center px-3 text-sm text-[#204C49]',
-                                                        colorClassMap[entry.row.color],
+                                                        'absolute top-0 h-full rounded-md border-2 bg-white flex items-center px-3 text-sm font-medium',
                                                         colorBorderMap[entry.row.color],
+                                                        colorTextMap[entry.row.color],
                                                         entry.row.isInProgress ? 'animate-pulse' : ''
                                                     )}
                                                     style={{
@@ -646,9 +725,7 @@ export default function LabelTimelinePanel({
                                                     }}
                                                 >
                                                     {entry.row.label}
-                                                    {entry.row.isInProgress
-                                                        ? ' (recording)'
-                                                        : ''}
+                                                    {entry.row.isInProgress ? ' •' : ''}
                                                 </div>
                                             );
                                         })}
@@ -662,7 +739,7 @@ export default function LabelTimelinePanel({
 
             {viewMode === 'timeline' && (
                 <div className="rounded-[16px] border border-[#D3D3D3] bg-white p-3">
-                <h3 className="mb-3 font-geist text-[25px] font-[550] leading-tight text-black">
+                <h3 className="mb-3 font-geist text-[20px] font-[550] leading-tight text-black">
                     Event Log
                 </h3>
 
@@ -723,6 +800,7 @@ export default function LabelTimelinePanel({
                 </div>
                 </div>
             )}
+            </div>
         </div>
     );
 }

--- a/frontend/components/nodes/machine-learning-node/machine-learning-node.tsx
+++ b/frontend/components/nodes/machine-learning-node/machine-learning-node.tsx
@@ -28,6 +28,7 @@ export default function MachineLearningNode({ id }: MachineLearningNodeProps) {
                 n.id === id ? { ...n, data: { ...n.data, config } } : n
             )
         );
+        window.dispatchEvent(new Event('node-config-changed'));
     }, [id, reactFlowInstance, selectedPrediction]);
 
     React.useEffect(() => {

--- a/frontend/components/nodes/resampling-node/resampling-node.tsx
+++ b/frontend/components/nodes/resampling-node/resampling-node.tsx
@@ -20,6 +20,7 @@ export default function ResamplingNode({ id, data }: ResamplingNodeProps) {
     // Persist state to node data
     React.useEffect(() => {
         reactFlowInstance.updateNodeData(id, { rate, customRate });
+        window.dispatchEvent(new Event('node-config-changed'));
     }, [id, rate, customRate, reactFlowInstance]);
 
     // Dispatch config update for future websocket integration

--- a/frontend/components/nodes/window-node/window-node.tsx
+++ b/frontend/components/nodes/window-node/window-node.tsx
@@ -6,16 +6,22 @@ import WindowComboBox, { type WindowOption } from './window-combo-box';
 
 interface WindowNodeProps {
     id?: string;
-    // data?: any;
+    data?: { config?: { chunk_size?: number; overlap_size?: number }; selectedOption?: WindowOption };
 }
 
-export default function WindowNode({ id }: WindowNodeProps) {
+export default function WindowNode({ id, data }: WindowNodeProps) {
     const DEFAULT_WINDOW_SIZE = 64;
     const DEFAULT_OVERLAP_SIZE = 0;
 
-    const [windowSize, setWindowSize] = React.useState<number>(DEFAULT_WINDOW_SIZE);
-    const [overlapSize, setOverlapSize] = React.useState<number>(DEFAULT_OVERLAP_SIZE);
-    const [selectedOption, setSelectedOption] = React.useState<WindowOption>('default');
+    const [windowSize, setWindowSize] = React.useState<number>(
+        data?.config?.chunk_size ?? DEFAULT_WINDOW_SIZE
+    );
+    const [overlapSize, setOverlapSize] = React.useState<number>(
+        data?.config?.overlap_size ?? DEFAULT_OVERLAP_SIZE
+    );
+    const [selectedOption, setSelectedOption] = React.useState<WindowOption>(
+        data?.selectedOption ?? 'default'
+    );
 
     const [isConnected, setIsConnected] = React.useState(false);
     
@@ -44,10 +50,11 @@ export default function WindowNode({ id }: WindowNodeProps) {
         const config = buildConfig();
         reactFlowInstance.setNodes((nds) =>
             nds.map((n) =>
-                n.id === id ? { ...n, data: { ...n.data, config } } : n
+                n.id === id ? { ...n, data: { ...n.data, config, selectedOption } } : n
             )
         );
-    }, [id, reactFlowInstance, windowSize, overlapSize, isValidConfig]);
+        window.dispatchEvent(new Event('node-config-changed'));
+    }, [id, reactFlowInstance, windowSize, overlapSize, selectedOption, isValidConfig]);
 
 
     // Check connection status and update state

--- a/frontend/components/ui-header/settings-bar.tsx
+++ b/frontend/components/ui-header/settings-bar.tsx
@@ -52,6 +52,8 @@ export default function SettingsBar() {
     const [isSaving, setIsSaving] = useState(false);
     const [isLoading, setIsLoading] = useState(false);
     const [isDirty, setIsDirty] = useState(false);
+    const [isLoadWarningOpen, setIsLoadWarningOpen] = useState(false);
+    const [activeSessionName, setActiveSessionName] = useState<string | null>(null);
 
     // Track unsaved canvas changes
     useEffect(() => {
@@ -62,6 +64,16 @@ export default function SettingsBar() {
             window.removeEventListener('canvas-changed', handler);
             window.removeEventListener('reactflow-edges-changed', handler);
         };
+    }, []);
+
+    // Auto-create an unsaved session on app open so streaming is always available.
+    // The "(unsaved)" prefix keeps it out of the load/save lists.
+    useEffect(() => {
+        if (activeSessionId !== null) return;
+        createSession(`(unsaved) ${new Date().toISOString()}`)
+            .then((s) => { setActiveSessionId(s.id); setActiveSessionName(null); })
+            .catch((e) => console.error('Failed to auto-create session:', e));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     // Timer effect - starts/stops based on dataStreaming state
@@ -102,17 +114,10 @@ export default function SettingsBar() {
     };
 
     const handleConfirmReset = () => {
-        // Stop the data stream and reset the timer
         setDataStreaming(false);
         setLeftTimerSeconds(0);
-
-        // Broadcast a reset event so the flow view can clear nodes/edges
-        try {
-            window.dispatchEvent(new Event('pipeline-reset'));
-        } catch (_) {
-            // no-op if window is unavailable
-        }
-
+        window.dispatchEvent(new Event('pipeline-reset'));
+        setIsDirty(true);
         setIsResetDialogOpen(false);
     };
 
@@ -172,7 +177,9 @@ export default function SettingsBar() {
         setFetchingFor('save');
         try {
             const fetchedSessions = await getSessions();
-            setSessions(fetchedSessions);
+            setSessions(fetchedSessions.filter(
+                (s) => !s.name.startsWith('Label Session ') && !s.name.startsWith('(unsaved) ') && !s.name.startsWith('Session ')
+            ));
             setSessionModalMode('save');
             setIsSessionModalOpen(true);
         } catch (error) {
@@ -186,16 +193,15 @@ export default function SettingsBar() {
         }
     };
 
-    const handleLoadClick = async () => {
-        if (isSaving || isLoading || isFetchingSessions) {
-            return;
-        }
-
+    const openLoadModal = async () => {
         setIsFetchingSessions(true);
         setFetchingFor('load');
         try {
             const fetchedSessions = await getSessions();
-            setSessions(fetchedSessions);
+            // Filter out orphaned label-node sessions created by old code.
+            setSessions(fetchedSessions.filter(
+                (s) => !s.name.startsWith('Label Session ') && !s.name.startsWith('(unsaved) ') && !s.name.startsWith('Session ')
+            ));
             setSessionModalMode('load');
             setIsSessionModalOpen(true);
         } catch (error) {
@@ -206,6 +212,15 @@ export default function SettingsBar() {
         } finally {
             setIsFetchingSessions(false);
             setFetchingFor(null);
+        }
+    };
+
+    const handleLoadClick = () => {
+        if (isSaving || isLoading || isFetchingSessions) return;
+        if (isDirty) {
+            setIsLoadWarningOpen(true);
+        } else {
+            void openLoadModal();
         }
     };
 
@@ -227,7 +242,13 @@ export default function SettingsBar() {
         setLeftTimerSeconds(0);
         window.dispatchEvent(new Event('pipeline-reset'));
         setIsNewDialogOpen(false);
-        notifications.success({ title: 'New session started' });
+        createSession(`(unsaved) ${new Date().toISOString()}`)
+            .then((s) => {
+                setActiveSessionId(s.id);
+                setActiveSessionName(null);
+                notifications.success({ title: 'New session started' });
+            })
+            .catch(() => notifications.error({ title: 'Could not create session' }));
     };
 
     const handleCreateAndSaveSession = async (sessionName: string) => {
@@ -385,6 +406,31 @@ export default function SettingsBar() {
                             <Button variant="outline">Cancel</Button>
                         </DialogClose>
                         <Button className="bg-red-500" onClick={handleConfirmNew}>Confirm</Button>
+                    </div>
+                </DialogContent>
+            </Dialog>
+
+            <Dialog open={isLoadWarningOpen} onOpenChange={setIsLoadWarningOpen}>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Load a different session?</DialogTitle>
+                        <DialogDescription>
+                            Your current session has unsaved changes. Loading a new session will discard them. Save first if you want to keep your work.
+                        </DialogDescription>
+                    </DialogHeader>
+                    <div className="flex justify-end gap-2 mt-4">
+                        <DialogClose asChild>
+                            <Button variant="outline">Cancel</Button>
+                        </DialogClose>
+                        <Button
+                            className="bg-red-500"
+                            onClick={() => {
+                                setIsLoadWarningOpen(false);
+                                void openLoadModal();
+                            }}
+                        >
+                            Discard & Load
+                        </Button>
                     </div>
                 </DialogContent>
             </Dialog>

--- a/frontend/components/ui-header/settings-bar.tsx
+++ b/frontend/components/ui-header/settings-bar.tsx
@@ -36,6 +36,8 @@ export default function SettingsBar() {
         setDataStreaming,
         activeSessionId,
         setActiveSessionId,
+        activeSessionName,
+        setActiveSessionName,
     } = useGlobalContext();
     const notifications = useNotifications();
     const [leftTimerSeconds, setLeftTimerSeconds] = useState(0);
@@ -53,16 +55,28 @@ export default function SettingsBar() {
     const [isLoading, setIsLoading] = useState(false);
     const [isDirty, setIsDirty] = useState(false);
     const [isLoadWarningOpen, setIsLoadWarningOpen] = useState(false);
-    const [activeSessionName, setActiveSessionName] = useState<string | null>(null);
 
-    // Track unsaved canvas changes
+    const isUnsavedSession = activeSessionName === null;
+
+    // Suppress dirty-tracking for a short window after Load/New, since
+    // restored nodes re-emit `node-config-changed` as they hydrate (combo
+    // boxes wire their persistence useEffects on mount, and connection
+    // status is rechecked on a 1s interval).
+    const suppressDirtyUntilRef = useRef<number>(0);
+
+    // Track unsaved canvas + node config changes
     useEffect(() => {
-        const handler = () => setIsDirty(true);
+        const handler = () => {
+            if (Date.now() < suppressDirtyUntilRef.current) return;
+            setIsDirty(true);
+        };
         window.addEventListener('canvas-changed', handler);
         window.addEventListener('reactflow-edges-changed', handler);
+        window.addEventListener('node-config-changed', handler);
         return () => {
             window.removeEventListener('canvas-changed', handler);
             window.removeEventListener('reactflow-edges-changed', handler);
+            window.removeEventListener('node-config-changed', handler);
         };
     }, []);
 
@@ -156,7 +170,8 @@ export default function SettingsBar() {
             return;
         }
 
-        if (activeSessionId !== null) {
+        // Save directly only when this is a real, named session
+        if (activeSessionId !== null && !isUnsavedSession) {
             setIsSaving(true);
             try {
                 await handleSaveToExistingSession(activeSessionId);
@@ -173,6 +188,7 @@ export default function SettingsBar() {
             return;
         }
 
+        // Unsaved (auto-created) session — prompt the user for a name
         setIsFetchingSessions(true);
         setFetchingFor('save');
         try {
@@ -217,6 +233,10 @@ export default function SettingsBar() {
 
     const handleLoadClick = () => {
         if (isSaving || isLoading || isFetchingSessions) return;
+        if (dataStreaming) {
+            notifications.error({ title: 'Stop the data stream before doing this.' });
+            return;
+        }
         if (isDirty) {
             setIsLoadWarningOpen(true);
         } else {
@@ -228,6 +248,10 @@ export default function SettingsBar() {
         if (isSaving || isLoading || isFetchingSessions) {
             return;
         }
+        if (dataStreaming) {
+            notifications.error({ title: 'Stop the data stream before doing this.' });
+            return;
+        }
         if (isDirty) {
             setIsNewDialogOpen(true);
         } else {
@@ -236,7 +260,9 @@ export default function SettingsBar() {
     };
 
     const handleConfirmNew = () => {
+        suppressDirtyUntilRef.current = Date.now() + 2000;
         setActiveSessionId(null);
+        setActiveSessionName(null);
         setIsDirty(false);
         setDataStreaming(false);
         setLeftTimerSeconds(0);
@@ -258,6 +284,7 @@ export default function SettingsBar() {
             const createdSession = await createSession(sessionName);
             await saveFrontendState(createdSession.id, state);
             setActiveSessionId(createdSession.id);
+            setActiveSessionName(createdSession.name);
             setIsDirty(false);
             setIsSessionModalOpen(false);
             notifications.success({ title: 'Session saved successfully' });
@@ -279,12 +306,16 @@ export default function SettingsBar() {
                 throw new Error('Loaded session payload has an invalid format.');
             }
 
+            suppressDirtyUntilRef.current = Date.now() + 2000;
             window.dispatchEvent(
                 new CustomEvent('restore-frontend-state', {
                     detail: loadedPayload,
                 })
             );
             setActiveSessionId(sessionId);
+            const loaded = sessions.find((s) => s.id === sessionId);
+            setActiveSessionName(loaded?.name ?? null);
+            setIsDirty(false);
             setIsSessionModalOpen(false);
             notifications.success({ title: 'Session loaded successfully' });
         } catch (error) {
@@ -309,7 +340,7 @@ export default function SettingsBar() {
             {/* Session ID, Tutorials */}
             <Menubar>
                 <span className="px-3 py-1 text-sm">
-                    Session {activeSessionId ?? 'ID'}
+                    {activeSessionName ?? (activeSessionId !== null ? 'Unsaved session' : 'New session')}
                 </span>
                 <button className="px-3 py-1 text-sm rounded-sm hover:bg-accent hover:text-accent-foreground hover:underline">
                     Tutorials

--- a/frontend/components/ui-header/settings-bar.tsx
+++ b/frontend/components/ui-header/settings-bar.tsx
@@ -128,10 +128,12 @@ export default function SettingsBar() {
     };
 
     const handleConfirmReset = () => {
+        suppressDirtyUntilRef.current = Date.now() + 2000;
         setDataStreaming(false);
         setLeftTimerSeconds(0);
+        setActiveSessionName(null);
+        setIsDirty(false);
         window.dispatchEvent(new Event('pipeline-reset'));
-        setIsDirty(true);
         setIsResetDialogOpen(false);
     };
 

--- a/frontend/components/ui-header/settings-bar.tsx
+++ b/frontend/components/ui-header/settings-bar.tsx
@@ -23,6 +23,8 @@ import {
     getSessions,
     loadFrontendState,
     saveFrontendState,
+    getTimeLabels,
+    saveTimeLabels,
     SessionSummary,
 } from '@/lib/session-api';
 import {
@@ -282,9 +284,34 @@ export default function SettingsBar() {
     const handleCreateAndSaveSession = async (sessionName: string) => {
         setIsSaving(true);
         try {
-            const state = await requestFrontendState();
+            const oldSessionId = activeSessionId;
+            const [state, oldLabels] = await Promise.all([
+                requestFrontendState(),
+                oldSessionId !== null
+                    ? getTimeLabels(oldSessionId, '1970-01-01T00:00:00Z', '2100-01-01T00:00:00Z')
+                          .catch(() => [])
+                    : Promise.resolve([]),
+            ]);
+
             const createdSession = await createSession(sessionName);
             await saveFrontendState(createdSession.id, state);
+
+            // Migrate labels from the old (unsaved) session to the new named session.
+            // Note: EEG data cannot be migrated without a backend rename endpoint — see backend task.
+            const labelsToMigrate = oldLabels
+                .filter((l) => l.end_timestamp !== null)
+                .map((l) => ({
+                    start_timestamp: l.start_timestamp,
+                    end_timestamp: l.end_timestamp!,
+                    label: l.label,
+                    color: l.color,
+                }));
+            if (labelsToMigrate.length > 0) {
+                await saveTimeLabels(createdSession.id, labelsToMigrate).catch((e) =>
+                    console.warn('[session] label migration failed:', e)
+                );
+            }
+
             setActiveSessionId(createdSession.id);
             setActiveSessionName(createdSession.name);
             setIsDirty(false);

--- a/frontend/components/ui-react-flow/react-flow-view.tsx
+++ b/frontend/components/ui-react-flow/react-flow-view.tsx
@@ -30,6 +30,7 @@ import MachineLearningNode from '@/components/nodes/machine-learning-node/machin
 import ResamplingNode from '@/components/nodes/resampling-node/resampling-node';
 import SignalGraphNode from '@/components/nodes/signal-graph-node/signal-graph-node';
 import WindowNode from '@/components/nodes/window-node/window-node';
+import LabelNode from '@/components/nodes/label-node/label-node';
 
 import Sidebar from '@/components/ui-sidebar/sidebar';
 import {
@@ -49,6 +50,7 @@ const nodeTypes = {
     'machine-learning-node': MachineLearningNode,
     'signal-graph-node': SignalGraphNode,
     'window-node': WindowNode,
+    'label-node': LabelNode,
 };
 
 let id = 0;

--- a/frontend/components/ui-sidebar/sidebar.tsx
+++ b/frontend/components/ui-sidebar/sidebar.tsx
@@ -56,6 +56,12 @@ export default function Sidebar() {
             label: 'Window Node',
             description: 'Configure windowing parameters for data streams',
             category: 'Nodes',
+        },
+        {
+            id: 'label-node',
+            label: 'Labeling Node',
+            description: 'Label data and create labels',
+            category: 'Nodes',
         }
     ];
 

--- a/frontend/context/GlobalContext.tsx
+++ b/frontend/context/GlobalContext.tsx
@@ -10,6 +10,8 @@ type GlobalContextType = {
     setDataStreaming: React.Dispatch<React.SetStateAction<boolean>>;
     activeSessionId: number | null;
     setActiveSessionId: React.Dispatch<React.SetStateAction<number | null>>;
+    activeSessionName: string | null;
+    setActiveSessionName: React.Dispatch<React.SetStateAction<string | null>>;
 };
 
 const GlobalContext = createContext<GlobalContextType | undefined>(undefined);
@@ -17,6 +19,7 @@ const GlobalContext = createContext<GlobalContextType | undefined>(undefined);
 export const GlobalProvider = ({ children }: { children: ReactNode }) => {
     const [dataStreaming, setDataStreaming] = useState(false);
     const [activeSessionId, setActiveSessionId] = useState<number | null>(null);
+    const [activeSessionName, setActiveSessionName] = useState<string | null>(null);
 
     return (
         <GlobalContext.Provider value={{
@@ -24,6 +27,8 @@ export const GlobalProvider = ({ children }: { children: ReactNode }) => {
             setDataStreaming,
             activeSessionId,
             setActiveSessionId,
+            activeSessionName,
+            setActiveSessionName,
         }}>
             {children}
         </GlobalContext.Provider>

--- a/frontend/lib/frontend-state.ts
+++ b/frontend/lib/frontend-state.ts
@@ -5,6 +5,33 @@ export type FrontendWorkspaceState = {
     edges: Edge[];
 };
 
+function isValidNode(value: unknown): boolean {
+    if (!value || typeof value !== 'object') return false;
+    const n = value as { id?: unknown; type?: unknown; data?: unknown };
+    return (
+        typeof n.id === 'string' &&
+        n.id.length > 0 &&
+        typeof n.type === 'string' &&
+        n.type.length > 0 &&
+        n.data !== undefined &&
+        n.data !== null &&
+        typeof n.data === 'object'
+    );
+}
+
+function isValidEdge(value: unknown): boolean {
+    if (!value || typeof value !== 'object') return false;
+    const e = value as { id?: unknown; source?: unknown; target?: unknown };
+    return (
+        typeof e.id === 'string' &&
+        e.id.length > 0 &&
+        typeof e.source === 'string' &&
+        e.source.length > 0 &&
+        typeof e.target === 'string' &&
+        e.target.length > 0
+    );
+}
+
 export function isFrontendWorkspaceState(
     value: unknown
 ): value is FrontendWorkspaceState {
@@ -17,6 +44,11 @@ export function isFrontendWorkspaceState(
         edges?: unknown;
     };
 
-    return Array.isArray(candidate.nodes) && Array.isArray(candidate.edges);
-}
+    if (!Array.isArray(candidate.nodes) || !Array.isArray(candidate.edges)) {
+        return false;
+    }
 
+    return (
+        candidate.nodes.every(isValidNode) && candidate.edges.every(isValidEdge)
+    );
+}

--- a/frontend/lib/session-api.ts
+++ b/frontend/lib/session-api.ts
@@ -85,11 +85,34 @@ export async function loadFrontendState(sessionId: number): Promise<unknown> {
     return parseJsonResponse<unknown>(response);
 }
 
+export type NewTimeLabel = {
+    start_timestamp: string;
+    end_timestamp: string | null;
+    label: string;
+    color: string;
+};
+
+export type TimeLabel = {
+    id: number;
+    session_id: number;
+    start_timestamp: string;
+    end_timestamp: string | null;
+    label: string;
+    color: string;
+};
+
+export type EegDataRow = {
+    time: string;
+    channel1: number;
+    channel2: number;
+    channel3: number;
+    channel4: number;
+};
+
 export async function saveTimeLabels(
     sessionId: number,
-    payload: { timestamp: string, label: string }[]
+    payload: NewTimeLabel[]
 ): Promise<void> {
-    // second parameter: payload: { timestamp: string, label: string }[]
     const response = await fetch(`/api/sessions/${sessionId}/time-label`, {
         method: 'POST',
         headers: {
@@ -102,3 +125,22 @@ export async function saveTimeLabels(
     }
 }
 
+export async function getTimeLabels(
+    sessionId: number,
+    start: string,
+    end: string
+): Promise<TimeLabel[]> {
+    const params = new URLSearchParams({ start, end });
+    const response = await fetch(`/api/sessions/${sessionId}/time-label?${params}`, { method: 'GET' });
+    return parseJsonResponse<TimeLabel[]>(response);
+}
+
+export async function getEegData(
+    sessionId: number,
+    start: string,
+    end: string
+): Promise<EegDataRow[]> {
+    const params = new URLSearchParams({ start, end });
+    const response = await fetch(`/api/sessions/${sessionId}/eeg-data?${params}`, { method: 'GET' });
+    return parseJsonResponse<EegDataRow[]>(response);
+}

--- a/frontend/lib/session-api.ts
+++ b/frontend/lib/session-api.ts
@@ -85,3 +85,20 @@ export async function loadFrontendState(sessionId: number): Promise<unknown> {
     return parseJsonResponse<unknown>(response);
 }
 
+export async function saveTimeLabels(
+    sessionId: number,
+    payload: { timestamp: string, label: string }[]
+): Promise<void> {
+    // second parameter: payload: { timestamp: string, label: string }[]
+    const response = await fetch(`/api/sessions/${sessionId}/time-label`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+    });
+    if (!response.ok) {
+        throw new Error(await parseErrorMessage(response));
+    }
+}
+

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -35,6 +35,7 @@
         "shadcn-ui": "^0.9.4",
         "tailwind-merge": "^2.6.0",
         "tailwindcss-animate": "^1.0.7",
+        "vaul": "^1.1.2",
         "ws": "^8.18.1"
       },
       "devDependencies": {
@@ -9801,6 +9802,19 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/vaul": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vaul/-/vaul-1.1.2.tgz",
+      "integrity": "sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-dialog": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/victory-vendor": {
       "version": "36.9.2",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -114,7 +114,6 @@
       "version": "7.26.7",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.7.tgz",
       "integrity": "sha512-SRijHmF0PSPgLIBYlWnG0hyeJLwXE2CgpsXaMOrtt2yp9/86ALw6oUlj9KYuZ0JN07T4eBMVIW4li/9S1j2BGA==",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -3460,7 +3459,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
       "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
       "devOptional": true,
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -3471,7 +3469,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.5.tgz",
       "integrity": "sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==",
       "devOptional": true,
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -3510,7 +3507,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.21.0.tgz",
       "integrity": "sha512-Wy+/sdEH9kI3w9civgACwabHbKl+qIOu0uFZ9IMKzX3Jpv9og0ZBJrZExGrPpFAY7rWsXuxs5e7CPPP17A4eYA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.21.0",
         "@typescript-eslint/types": "8.21.0",
@@ -3725,7 +3721,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4128,7 +4123,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -4962,7 +4956,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5476,7 +5469,6 @@
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5640,7 +5632,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.31.0.tgz",
       "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -8086,7 +8077,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.8",
         "picocolors": "^1.1.1",
@@ -8291,7 +8281,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -8303,7 +8292,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -9416,7 +9404,6 @@
       "version": "3.4.17",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -9663,7 +9650,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "devOptional": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,6 +36,7 @@
     "shadcn-ui": "^0.9.4",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
+    "vaul": "^1.1.2",
     "ws": "^8.18.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## What?

Reworked the Label node and fixed several session management bugs. Adds label timeline jumping, unique-label enforcement, live save behavior, a dedicated EEG data fetch route, and a settings-bar refresh for session selection. 

---

## How?

 - Label node rewrite (label-node.tsx, label-combo-box.tsx, label-timeline-panel.tsx): rebuilt the timeline panel to
  support jumping to labeled segments, enforce unique labels per session, and persist labels live on edit (instead of only  
  on pipeline end).
  - EEG data route: added app/api/sessions/[session_id]/eeg-data/route.ts and switched the frontend to use it for fetching  
  session EEG data.                                                                                                         
  - Session management fixes (settings-bar.tsx, frontend-state.ts, session-api.ts, GlobalContext.tsx): fixed bugs around
  switching/loading sessions and synced session state through global context.                                               
  - Minor prop/wiring updates to artifact-node, filter-node, resampling-node, machine-learning-node, and window-node to   
  match the new label/session flow. 

---

## Testing

- Manually verified in the browser:
    - Create labels on a running pipeline → labels appear live in timeline panel.
    - Duplicate label names are rejected.                                                                                   
    - Clicking a label in the timeline jumps the chart to that segment.
    - Switching sessions in the settings bar loads the correct EEG data via the new route.                                  
    - Saved labels persist after refresh. 