### PR TITLE
Label node fixes

### DIFF
--- a/frontend/app/home/page.tsx
+++ b/frontend/app/home/page.tsx
@@ -11,7 +11,7 @@ export default function Home() {
         <GlobalProvider>
             <WebSocketProvider>
             <NotificationsProvider>
-                <div className="h-screen flex flex-col">
+                <div className="h-screen flex flex-col overflow-hidden">
                     {/* Top section for header and settings bar */}
                     <div className="flex flex-col">
                         <AppHeader />

--- a/frontend/components/nodes/label-node/label-combo-box.tsx
+++ b/frontend/components/nodes/label-node/label-combo-box.tsx
@@ -31,6 +31,7 @@ interface ComboBoxProps {
     graphData: LabelGraphPoint[];
     sessionStartTimestamp: string | null;
     latestBackendTimestamp: string | null;
+    isLoadingLabels?: boolean;
     fetchDataForLabel?: (start: string, end: string) => Promise<LabelGraphPoint[]>;
 }
 
@@ -64,6 +65,7 @@ export default function ComboBox({
     graphData,
     sessionStartTimestamp,
     latestBackendTimestamp,
+    isLoadingLabels,
     fetchDataForLabel,
 }: ComboBoxProps) {
     return (
@@ -235,6 +237,7 @@ export default function ComboBox({
                 isConnected={isConnected}
                 isDataStreamOn={isDataStreamOn}
                 graphData={graphData}
+                isLoadingLabels={isLoadingLabels}
                 fetchDataForLabel={fetchDataForLabel}
             />
         </div>

--- a/frontend/components/nodes/label-node/label-node.tsx
+++ b/frontend/components/nodes/label-node/label-node.tsx
@@ -8,6 +8,7 @@ import ComboBox, { LabelColor } from './label-combo-box';
 import { LabelGraphPoint, TimelineLabelRow } from '@/components/nodes/label-node/label-timeline-panel';
 import { saveTimeLabels, getTimeLabels } from '@/lib/session-api';
 import { exportEEGData } from '@/lib/eeg-api';
+import { useNotifications } from '@/components/notifications';
 
 interface LabelNodeProps {
     id?: string;
@@ -83,7 +84,7 @@ export default function LabelNode({ id }: LabelNodeProps) {
     >(null);
     const [pendingEndTimestamp, setPendingEndTimestamp] = React.useState<string | null>(null);
     const [labeledMoments, setLabeledMoments] = React.useState<LabeledMoment[]>([]);
-    const [labelError, setLabelError] = React.useState<string | null>(null);
+    const [isLoadingLabels, setIsLoadingLabels] = React.useState(false);
     const labelsRef = React.useRef<LabeledMoment[]>([]);
     const sentLabelIdsRef = React.useRef<Set<string>>(new Set());
     const previousStreamStateRef = React.useRef(false);
@@ -91,18 +92,25 @@ export default function LabelNode({ id }: LabelNodeProps) {
 
     const { dataStreaming, activeSessionId } = useGlobalContext();
     const { renderData } = useNodeData(300, 15);
+    const notifications = useNotifications();
 
     const reactFlowInstance = useReactFlow();
 
     // Load persisted labels whenever the active session changes.
     const validColors: LabelColor[] = ['teal-700', 'teal-500', 'teal-300', 'mint-100'];
     React.useEffect(() => {
+        // Reset stream anchors so the timeline doesn't carry over state from a previous session.
+        setSessionStartTimestamp(null);
+        setLatestBackendTimestamp(null);
+
         if (activeSessionId === null) {
             setLabeledMoments([]);
+            setIsLoadingLabels(false);
             sentLabelIdsRef.current = new Set();
             momentCounterRef.current = 0;
             return;
         }
+        setIsLoadingLabels(true);
         getTimeLabels(activeSessionId, '1970-01-01T00:00:00Z', '2100-01-01T00:00:00Z')
             .then((labels) => {
                 const moments: LabeledMoment[] = labels
@@ -121,7 +129,8 @@ export default function LabelNode({ id }: LabelNodeProps) {
                 sentLabelIdsRef.current = new Set(moments.map((m) => m.id));
                 momentCounterRef.current = 0;
             })
-            .catch((e) => console.error('Failed to load time labels:', e));
+            .catch((e) => console.error('Failed to load time labels:', e))
+            .finally(() => setIsLoadingLabels(false));
     }, [activeSessionId]);
 
     const checkConnectionStatus = React.useCallback(() => {
@@ -226,8 +235,12 @@ export default function LabelNode({ id }: LabelNodeProps) {
             unsentLabels.forEach((moment) => sentLabelIdsRef.current.add(moment.id));
         } catch (e) {
             console.error('Failed to POST time labels:', e);
+            notifications.error({
+                title: 'Failed to save labels',
+                description: 'Your labels could not be saved. Please try stopping and restarting the stream.',
+            });
         }
-    }, [activeSessionId]);
+    }, [activeSessionId, notifications]);
 
     React.useEffect(() => {
         const wasStreaming = previousStreamStateRef.current;
@@ -235,17 +248,25 @@ export default function LabelNode({ id }: LabelNodeProps) {
 
         if (streamJustStopped) {
             if (isTriggerActive) {
-                setIsTriggerActive(false);
-                setActiveStartTimestamp(null);
-                setPendingEndTimestamp(null);
-                setIsLabelPopupOpen(false);
-                setLabelInputValue('');
+                if (latestBackendTimestamp) {
+                    // Auto-close the in-progress label and prompt the user to name it.
+                    setPendingEndTimestamp(latestBackendTimestamp);
+                    setIsTriggerActive(false);
+                    setIsLabelPopupOpen(true);
+                } else {
+                    // No timestamp available — silently cancel.
+                    setIsTriggerActive(false);
+                    setActiveStartTimestamp(null);
+                    setPendingEndTimestamp(null);
+                    setIsLabelPopupOpen(false);
+                    setLabelInputValue('');
+                }
             }
             void postLabelsToApi();
         }
 
         previousStreamStateRef.current = dataStreaming;
-    }, [dataStreaming, isTriggerActive, postLabelsToApi]);
+    }, [dataStreaming, isTriggerActive, latestBackendTimestamp, postLabelsToApi]);
 
     const handleTriggerClick = () => {
         if (!dataStreaming) {
@@ -278,7 +299,6 @@ export default function LabelNode({ id }: LabelNodeProps) {
     const handleCloseLabelPopup = () => {
         setIsLabelPopupOpen(false);
         setLabelInputValue('');
-        setLabelError(null);
         setActiveStartTimestamp(null);
         setPendingEndTimestamp(null);
         setIsTriggerActive(false);
@@ -291,12 +311,16 @@ export default function LabelNode({ id }: LabelNodeProps) {
         }
 
         const normalizedName = labelInputValue.trim() || 'Untitled';
-        const isDuplicate = labeledMoments.some((m) => m.label === normalizedName);
+        // Only check for duplicates among labels created this session (id prefix "moment-").
+        // Labels loaded from the backend have id prefix "backend-" and belong to a previous
+        // session or a prior load, so reusing their names in the current session is allowed.
+        const isDuplicate = labelsRef.current.some(
+            (m) => !m.id.startsWith('backend-') && m.label === normalizedName
+        );
         if (isDuplicate) {
-            setLabelError(`"${normalizedName}" already exists`);
+            notifications.error({ title: `Label "${normalizedName}" already exists in this session` });
             return;
         }
-        setLabelError(null);
 
         momentCounterRef.current += 1;
 
@@ -309,11 +333,13 @@ export default function LabelNode({ id }: LabelNodeProps) {
             source: 'Trigger',
         };
 
+        labelsRef.current = [...labelsRef.current, newLabeledMoment];
         setLabeledMoments((prev) => [...prev, newLabeledMoment]);
         setIsLabelPopupOpen(false);
         setLabelInputValue('');
         setActiveStartTimestamp(null);
         setPendingEndTimestamp(null);
+        void postLabelsToApi();
     };
 
     const handlePreviewOpen = () => {
@@ -463,15 +489,15 @@ export default function LabelNode({ id }: LabelNodeProps) {
                 isLabelPopupOpen={isLabelPopupOpen}
                 labelInputValue={labelInputValue}
                 selectedColor={selectedColor}
-                onLabelInputChange={(v) => { setLabelInputValue(v); setLabelError(null); }}
+                onLabelInputChange={setLabelInputValue}
                 onColorSelect={setSelectedColor}
-                labelError={labelError}
                 onConfirmLabel={handleConfirmLabel}
                 onCloseLabelPopup={handleCloseLabelPopup}
                 timelineRows={timelineRows}
                 graphData={graphData}
                 sessionStartTimestamp={sessionStartTimestamp}
                 latestBackendTimestamp={latestBackendTimestamp}
+                isLoadingLabels={isLoadingLabels}
                 fetchDataForLabel={handleFetchLabelData}
             />
         </div>

--- a/frontend/components/nodes/label-node/label-node.tsx
+++ b/frontend/components/nodes/label-node/label-node.tsx
@@ -22,7 +22,6 @@ interface LabeledMoment {
     source: 'Trigger';
 }
 
-
 function normalizeNodeTimestamp(raw: unknown): string | null {
     if (raw == null) return null;
 
@@ -430,8 +429,27 @@ export default function LabelNode({ id }: LabelNodeProps) {
                 }}
             />
 
+            {/* Output Handle - positioned to align with right circle */}
+            <Handle
+                type="source"
+                position={Position.Right}
+                id="labeling-output"
+                style={{
+                    right: '24px',
+                    top: '30px',
+                    transform: 'translateY(-50%)',
+                    width: '28px',
+                    height: '28px',
+                    backgroundColor: 'transparent',
+                    border: '2px solid transparent',
+                    borderRadius: '50%',
+                    zIndex: 20,
+                    cursor: 'crosshair',
+                    pointerEvents: 'all',
+                }}
+            />
 
-            <ComboBox 
+            <ComboBox
                 isConnected={isConnected}
                 isDataStreamOn={dataStreaming}
                 isTriggerActive={isTriggerActive}

--- a/frontend/components/nodes/label-node/label-timeline-panel.tsx
+++ b/frontend/components/nodes/label-node/label-timeline-panel.tsx
@@ -471,6 +471,7 @@ export default function LabelTimelinePanel({
                     >
                         {isConnected && <span className="w-3 h-3 rounded-full bg-white" />}
                     </span>
+
                     {/* Status dot */}
                     <div
                         className={cn(

--- a/frontend/components/nodes/label-node/label-timeline-panel.tsx
+++ b/frontend/components/nodes/label-node/label-timeline-panel.tsx
@@ -45,6 +45,7 @@ export interface LabelTimelinePanelProps {
     onTimelineViewClick?: () => void;
     viewMode: 'timeline' | 'graph';
     graphData: LabelGraphPoint[];
+    isLoadingLabels?: boolean;
     fetchDataForLabel?: (start: string, end: string) => Promise<LabelGraphPoint[]>;
 }
 
@@ -153,22 +154,28 @@ export default function LabelTimelinePanel({
     isConnected,
     isDataStreamOn,
     graphData,
+    isLoadingLabels = false,
     fetchDataForLabel,
 }: LabelTimelinePanelProps) {
     const latestMs = parseTimestampMs(latestBackendTimestamp);
     const fallbackStartMs = parseTimestampMs(sessionStartTimestamp);
 
     const axisStartMs = React.useMemo(() => {
+        // When the current stream has started, anchor the timeline to it.
+        // This prevents loaded historical labels (from a previous session) from
+        // corrupting the axis scale by spanning an enormous time range.
+        if (fallbackStartMs !== null) {
+            return fallbackStartMs;
+        }
+
+        // No active stream — use the earliest label timestamp (e.g. viewing a
+        // loaded session's labels without having started a new stream yet).
         const startCandidates = rows
             .map((row) => parseTimestampMs(row.startTimestamp))
             .filter((value): value is number => value !== null);
 
         if (startCandidates.length > 0) {
             return Math.min(...startCandidates);
-        }
-
-        if (fallbackStartMs !== null) {
-            return fallbackStartMs;
         }
 
         if (latestMs !== null) {
@@ -194,7 +201,9 @@ export default function LabelTimelinePanel({
 
     const elapsedDurationMs = Math.max(axisEndMs - axisStartMs, 1);
     const virtualDurationMs = Math.max(elapsedDurationMs, VISIBLE_WINDOW_MS);
-    const virtualTrackWidthPercent = (virtualDurationMs / VISIBLE_WINDOW_MS) * 100;
+    // Cap at 2000% (20× the visible window) so mixed historical/current timestamps
+    // don't produce an impossibly wide track that causes layout glitches.
+    const virtualTrackWidthPercent = Math.min((virtualDurationMs / VISIBLE_WINDOW_MS) * 100, 2000);
 
     const ticks = React.useMemo(() => {
         const tickCount = Math.floor(virtualDurationMs / TICK_INTERVAL_MS) + 1;
@@ -445,13 +454,20 @@ export default function LabelTimelinePanel({
             return;
         }
 
+        // Only auto-scroll to the live edge when a stream is active.
+        // When viewing a loaded session with no active stream, keep the
+        // viewport at the left so all tick labels and labels are visible.
+        if (latestMs === null) {
+            return;
+        }
+
         const node = timelineScrollRef.current;
         if (!node || !isAtLiveEdgeRef.current) {
             return;
         }
 
         node.scrollLeft = Math.max(node.scrollWidth - node.clientWidth, 0);
-    }, [axisEndMs, laneGroups.length, virtualTrackWidthPercent, viewMode]);
+    }, [axisEndMs, laneGroups.length, latestMs, virtualTrackWidthPercent, viewMode]);
 
     if (!isExpanded) {
         return null;
@@ -726,7 +742,7 @@ export default function LabelTimelinePanel({
                                 {ticks.map((tick) => (
                                     <div
                                         key={`${tick.ratio}-${tick.label}`}
-                                        className="absolute top-0 -translate-x-1/2 text-xs text-[#7A7A7A]"
+                                        className="absolute top-0 -translate-x-1/2 text-xs text-[#7A7A7A] whitespace-nowrap"
                                         style={{ left: `${tick.ratio * 100}%` }}
                                     >
                                         {tick.label}
@@ -735,13 +751,22 @@ export default function LabelTimelinePanel({
                             </div>
 
                             <div className="space-y-2">
-                                {laneGroups.length === 0 && (
+                                {isLoadingLabels && (
+                                    <div className="flex flex-col items-center justify-center gap-3 py-8">
+                                        <svg className="animate-spin h-6 w-6 text-[#6CAFA4]" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                                            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                                            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                                        </svg>
+                                        <span className="text-sm text-[#8A8A8A]">Loading labels…</span>
+                                    </div>
+                                )}
+                                {!isLoadingLabels && laneGroups.length === 0 && (
                                     <div className="py-3 text-sm text-[#8A8A8A]">
                                         No labels yet. Start/stop Trigger to add moments.
                                     </div>
                                 )}
 
-                                {laneGroups.map((laneEntries, laneIndex) => (
+                                {!isLoadingLabels && laneGroups.map((laneEntries, laneIndex) => (
                                     <div
                                         key={`timeline-lane-${laneIndex}`}
                                         className="relative h-8 w-full"
@@ -811,7 +836,20 @@ export default function LabelTimelinePanel({
                             </tr>
                         </thead>
                         <tbody>
-                            {tableRows.length === 0 && (
+                            {isLoadingLabels && (
+                                <tr>
+                                    <td colSpan={4} className="px-3 py-4">
+                                        <div className="flex items-center gap-3 text-[#8A8A8A]">
+                                            <svg className="animate-spin h-4 w-4 text-[#6CAFA4] flex-shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                                                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                                                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                                            </svg>
+                                            <span className="text-sm">Loading saved labels…</span>
+                                        </div>
+                                    </td>
+                                </tr>
+                            )}
+                            {!isLoadingLabels && tableRows.length === 0 && (
                                 <tr>
                                     <td
                                         colSpan={4}
@@ -822,7 +860,7 @@ export default function LabelTimelinePanel({
                                 </tr>
                             )}
 
-                            {tableRows.map((row) => {
+                            {!isLoadingLabels && tableRows.map((row) => {
                                 const startMs = parseTimestampMs(row.startTimestamp);
                                 const endMs = parseTimestampMs(
                                     row.endTimestamp ?? latestBackendTimestamp

--- a/frontend/components/ui-sidebar/sidebar.tsx
+++ b/frontend/components/ui-sidebar/sidebar.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Card } from '@/components/ui/card';
 import {
     ResizableHandle,
     ResizablePanel,
@@ -14,71 +14,87 @@ import { ChevronDown, X } from "lucide-react";
 
 export default function Sidebar() {
 
-    const AvailableNodes = [
+    const NodeCategories = [
         {
-            id: 'source-node',
-            label: 'Source Node',
-            description: 'No Connection',
-            category: 'Nodes',
+            category: 'Input',
+            nodes: [
+                {
+                    id: 'source-node',
+                    label: 'Source Node',
+                    description: 'Connect to an EEG data source',
+                },
+            ],
         },
         {
-            id: 'artifact-node',
-            label: 'Artifact Node',
-            description: 'Preprocessing step for artifact removal',
-            category: 'Nodes',
+            category: 'Preprocessing',
+            nodes: [
+                {
+                    id: 'resampling-node',
+                    label: 'Resampling Node',
+                    description: 'Resample EEG data to a target frequency',
+                },
+                {
+                    id: 'filter-node',
+                    label: 'Filter Node',
+                    description: 'Filter and process data streams',
+                },
+                {
+                    id: 'artifact-node',
+                    label: 'Artifact Node',
+                    description: 'Preprocessing step for artifact removal',
+                },
+                {
+                    id: 'window-node',
+                    label: 'Window Node',
+                    description: 'Configure windowing parameters for data streams',
+                },
+            ],
         },
         {
-            id: 'filter-node',
-            label: 'Filter Node',
-            description: 'Filter and process data streams',
-            category: 'Nodes',
+            category: 'Analysis',
+            nodes: [
+                {
+                    id: 'machine-learning-node',
+                    label: 'ML Node',
+                    description: 'Machine learning prediction and analysis',
+                },
+            ],
         },
         {
-            id: 'machine-learning-node',
-            label: 'ML Node',
-            description: 'Machine learning prediction and analysis',
-            category: 'Nodes',
+            category: 'Output',
+            nodes: [
+                {
+                    id: 'signal-graph-node',
+                    label: 'Chart Node',
+                    description: 'Visualize data and create charts',
+                },
+                {
+                    id: 'label-node',
+                    label: 'Labeling Node',
+                    description: 'Label data and create labels',
+                },
+            ],
         },
-        {
-            id: 'signal-graph-node',
-            label: 'Chart Node',
-            description: 'Visualize data and create charts',
-            category: 'Nodes',
-        },
-        {
-            id: 'resampling-node',
-            label: 'Resampling Node',
-            description: 'Resample EEG data to a target frequency',
-            category: 'Nodes',
-        },
-        {
-            id: 'window-node',
-            label: 'Window Node',
-            description: 'Configure windowing parameters for data streams',
-            category: 'Nodes',
-        },
-        {
-            id: 'label-node',
-            label: 'Labeling Node',
-            description: 'Label data and create labels',
-            category: 'Nodes',
-        }
     ];
+
+    const allNodes = NodeCategories.flatMap((c) => c.nodes);
 
     const [searchTerm, setSearchTerm] = useState('');
     const [collapsed, setCollapsed] = useState(false);
     const [open, setOpen] = useState(true);
 
-    const filteredNodes = AvailableNodes.filter((node) =>
+    const filteredNodes = allNodes.filter((node) =>
         node.label.toLowerCase().includes(searchTerm.toLowerCase())
     );
 
     return (
-        <ResizablePanelGroup direction="horizontal" className="border-none min-h-[200px] max-w-md rounded-lg border md:min-w-[450px]">
-            <ResizablePanel defaultSize={60} minSize={60} className=" ">
-                <Card className="max-h-[calc(100vh-2rem)] flex flex-col ">
-                    <CardHeader className="flex flex-row items-center justify-between pb-4">
-                        <CardTitle className="font-ibmplex font-semibold text-xl text-black">Menu</CardTitle>
+        <ResizablePanelGroup direction="horizontal" className="border-none min-h-[200px] max-w-md rounded-lg border md:min-w-[480px]">
+            <ResizablePanel defaultSize={60} minSize={60}>
+                <Card className="flex flex-col overflow-hidden" style={{ maxHeight: 'calc(100vh - 2rem)' }}>
+
+                    {/* ── Section 1: Header ── */}
+                    <div className="flex-shrink-0 flex flex-row items-center justify-between px-6 pt-6 pb-3">
+                        <span className="font-ibmplex font-semibold text-xl text-black">Menu</span>
                         <button
                             onClick={() => setCollapsed(!collapsed)}
                             className="p-1 rounded hover:bg-gray-100"
@@ -86,40 +102,66 @@ export default function Sidebar() {
                         >
                             {collapsed ? <ChevronDown size={15} /> : <Cross1 />}
                         </button>
-                    </CardHeader>
+                    </div>
 
                     {!collapsed && (
                         <>
-                            <div className='pb-4'>
+                            {/* Search — part of header area, doesn't scroll */}
+                            <div className="flex-shrink-0 px-6 pb-3">
                                 <Input
                                     type="text"
                                     placeholder="Search"
                                     value={searchTerm}
                                     onChange={(e) => setSearchTerm(e.target.value)}
-                                    className="items-center px-7 py-2 mx-4 border border-gray-200 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-700 placeholder-gray-500"
+                                    className="w-full border border-gray-200 rounded-md pl-7 pr-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-700 placeholder-gray-500"
                                 />
                             </div>
 
-                            <CardContent className="overflow-y-auto flex-1 px-4 pb-4 space-y-3">
-                                {(searchTerm ? filteredNodes : AvailableNodes).map((node) => (
-                                    <NodeButton
-                                        key={node.id}
-                                        id={node.id}
-                                        label={node.label}
-                                        description={node.description}
-                                    />
-                                ))}
-                                {open && (
+                            {/* ── Section 2: Scrollable node list ── */}
+                            <div className="overflow-y-auto px-6 py-2 space-y-3" style={{ maxHeight: '40vh' }}>
+                                {searchTerm ? (
+                                    filteredNodes.map((node) => (
+                                        <NodeButton
+                                            key={node.id}
+                                            id={node.id}
+                                            label={node.label}
+                                            description={node.description}
+                                        />
+                                    ))
+                                ) : (
+                                    NodeCategories.map((group) => (
+                                        <div key={group.category}>
+                                            <p className="mb-1.5 px-1 text-xs font-semibold uppercase tracking-widest text-gray-400">
+                                                {group.category}
+                                            </p>
+                                            <div className="space-y-2">
+                                                {group.nodes.map((node) => (
+                                                    <NodeButton
+                                                        key={node.id}
+                                                        id={node.id}
+                                                        label={node.label}
+                                                        description={node.description}
+                                                    />
+                                                ))}
+                                            </div>
+                                        </div>
+                                    ))
+                                )}
+                            </div>
+
+                            {/* ── Section 3: Warning footer (shrinks away when closed) ── */}
+                            {open && (
+                                <div className="flex-shrink-0 px-6 pb-6 pt-3">
                                     <Alert className="bg-[#EFEFF0] text-black flex justify-between items-start font-ibmplex">
                                         <AlertDescription className="text-[0.7rem]">
                                             Only <b>pre-processed</b> data is <b>saved</b> by default. To store raw data, only use the <b>Source Node</b> without adding any computations.
                                         </AlertDescription>
-                                        <button onClick={() => setOpen(false)} className="ml-2">
+                                        <button onClick={() => setOpen(false)} className="ml-2 flex-shrink-0">
                                             <X className="h-3 w-3" />
                                         </button>
                                     </Alert>
-                                )}
-                            </CardContent>
+                                </div>
+                            )}
                         </>
                     )}
                 </Card>

--- a/frontend/components/ui/input.tsx
+++ b/frontend/components/ui/input.tsx
@@ -7,7 +7,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
   ({ className, type, ...props }, ref) => {
     return (
         <div className="relative flex items-center">
-            <MagnifyingGlassIcon className="absolute left-6 text-[#96bdba]" />
+            <MagnifyingGlassIcon className="absolute left-3 text-[#96bdba]" />
             <input
                 type={type}
                 className={cn(


### PR DESCRIPTION

## What?

Finalizes the label node with several bug fixes and adds a refactored sidebar menu.

Label node fixes:
- In-progress label is auto-closed (with a naming prompt) when the data stream stops instead of being silently cancelled
- Labels are saved to the API immediately on confirm, not only when the stream stops
- Error toast shown when a label save fails
- Duplicate label name check scoped to the current session only; backend-loaded labels from previous sessions are excluded
- Whitespace-only label names correctly default to "Untitled"
- Loading spinner shown in the timeline preview while backend labels fetch after session load
- Timeline axis fixed: session timestamps reset on session change so historical labels don't corrupt the time scale
- Timeline no longer auto-scrolls to the right edge when there is no active stream, so tick labels are visible on load

Sidebar refactor:
- Nodes reorganised into processing-order categories: Input -> Preprocessing -> Analysis -> Output
- Three-section layout: fixed header (title + search + collapse), scrollable node list, dismissible warning footer that shrinks the card when closed
- Fixed search icon/text overlap
- Fixed whole-window vertical scroll caused by the ReactFlow canvas height: 100vh overflowing its flex parent

---

## How?

- label-node.tsx - added isLoadingLabels state around getTimeLabels fetch; fixed stale-ref bug on confirm by mutating - labelsRef.current directly before async POST; added useNotifications error toasts; scoped duplicate check to moment- prefixed IDs; reset stream anchors on session change
- label-timeline-panel.tsx - axisStartMs prefers fallbackStartMs (current stream anchor); virtualTrackWidthPercent capped at 2000%; auto-scroll gated on latestMs !== null; loading spinner added; tick labels get whitespace-nowrap
- label-combo-box.tsx - threaded isLoadingLabels prop through to LabelTimelinePanel
- sidebar.tsx - rewrote as three flex sections with overflow-y-auto node list; nodes grouped by processing-order category
- input.tsx - moved MagnifyingGlassIcon from left-6 to left-3 to align with input text
- home/page.tsx - added overflow-hidden to root h-screen div to prevent page-level scroll

---

## Testing

- Loaded a saved session - loading spinner appears, then labels render in timeline preview
- Started/stopped trigger mid-stream - naming popup appears on stream stop
- Confirmed label - saved immediately without needing to stop stream
- Entered whitespace-only label name - saved as "Untitled"
- Entered duplicate label name within same session - error toast shown, save blocked
- Disconnected backend mid-label - error toast shown on failed save
- Opened timeline preview on loaded session - tick labels visible at left, no auto-scroll to empty right side
- Sidebar node list scrolls independently; warning dismisses and card shrinks; search works across all categories
- No whole-window scroll after overflow-hidden fix