### PR TITLE
add code quality CI workflow: rustfmt, clippy, ruff

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,0 +1,62 @@
+name: Code quality
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  rustfmt:
+    name: rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - name: cargo fmt --check
+        working-directory: backend
+        run: cargo fmt --all -- --check
+
+  clippy:
+    name: clippy
+    runs-on: ubuntu-latest
+    env:
+      SQLX_OFFLINE: "true"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config build-essential cmake python3-dev
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: backend
+      - name: cargo clippy
+        working-directory: backend
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+  ruff-format:
+    name: ruff format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - run: pip install ruff
+      - run: ruff format --check .
+
+  ruff-check:
+    name: ruff check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - run: pip install ruff
+      - run: ruff check .


### PR DESCRIPTION
Add code quality CI workflow

## What?

Add a GitHub Actions workflow that enforces code formatting and linting on every PR and push to `main`: rustfmt and clippy for the Rust workspace, ruff format and ruff check for Python.

---

## How?

New file `.github/workflows/code-quality.yml` with four parallel jobs:

  - **rustfmt** — `cargo fmt --all -- --check` in `backend/`, toolchain via `dtolnay/rust-toolchain@stable` with the `rustfmt`
  component.
  - **clippy** — `cargo clippy --workspace --all-targets -- -D warnings` in `backend/`. Installs `cmake`, `pkg-config`,
  `python3-dev`, `build-essential` (mirrors the project Dockerfile), sets `SQLX_OFFLINE=true`, and caches the Rust build with `Swatinem/rust-cache@v2`.
  - **ruff format** — `ruff format --check .`
  - **ruff check** — `ruff check .`

---

## Testing

- Validated YAML structure locally.